### PR TITLE
Bugfix/fix npe open api generator

### DIFF
--- a/http-api/pom.xml
+++ b/http-api/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-http-api</artifactId>
-  <version>1.1</version>
+  <version>1.2-SNAPSHOT</version>
 
   <parent>
     <groupId>org.avaje</groupId>

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/DocContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/DocContext.java
@@ -200,7 +200,7 @@ public class DocContext {
   }
 
   private Writer createMetaWriter() throws IOException {
-    FileObject writer = filer.createResource(StandardLocation.CLASS_OUTPUT, "meta", "openapi.json", null);
+    FileObject writer = filer.createResource(StandardLocation.CLASS_OUTPUT, "meta", "openapi.json");
     return writer.openWriter();
   }
 

--- a/http-generator-spark/pom.xml
+++ b/http-generator-spark/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-http-generator-parent</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/test-client/pom.xml
+++ b/tests/test-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>java11-oss</artifactId>
     <groupId>org.avaje</groupId>
-    <version>2.1.2</version>
+    <version>2.3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-helidon/pom.xml
+++ b/tests/test-helidon/pom.xml
@@ -11,13 +11,13 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>2.2</version>
+    <version>2.3</version>
   </parent>
 
   <properties>
     <mainClass>org.example.Main</mainClass>
     <helidon-version>2.0.2</helidon-version>
-    <avaje-http-version>1.1-SNAPSHOT</avaje-http-version>
+    <avaje-http-version>1.2-SNAPSHOT</avaje-http-version>
   </properties>
 
   <dependencies>

--- a/tests/test-javalin/pom.xml
+++ b/tests/test-javalin/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>2.2</version>
+    <version>2.3</version>
   </parent>
 
   <properties>
@@ -20,7 +20,7 @@
     <swagger.version>2.0.8</swagger.version>
     <kotlin.version>1.3.71</kotlin.version>
     <jackson.version>2.11.1</jackson.version>
-    <avaje-http-version>1.1-SNAPSHOT</avaje-http-version>
+    <avaje-http-version>1.2-SNAPSHOT</avaje-http-version>
   </properties>
 
   <dependencies>

--- a/tests/test-jex/pom.xml
+++ b/tests/test-jex/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>2.2</version>
+    <version>2.3</version>
   </parent>
 
   <properties>

--- a/tests/test-spark/pom.xml
+++ b/tests/test-spark/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <main.class>org.example.myapp.Main</main.class>
     <swagger.version>2.0.8</swagger.version>
-    <avaje-http-version>1.1-SNAPSHOT</avaje-http-version>
+    <avaje-http-version>1.2-SNAPSHOT</avaje-http-version>
   </properties>
 
   <dependencies>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-spark-generator</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.2-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
```
Caused by: java.lang.NullPointerException
        at org.jetbrains.jps.javac.APIWrappers$FilerWrapper.createResource(APIWrappers.java:156)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.jetbrains.jps.javac.APIWrappers$1.invoke(APIWrappers.java:213)
        at com.sun.proxy.$Proxy27.createResource(Unknown Source)
        at io.avaje.http.generator.core.openapi.DocContext.createMetaWriter(DocContext.java:203)
        at io.avaje.http.generator.core.openapi.DocContext.writeApi(DocContext.java:180)
        at io.avaje.http.generator.core.BaseProcessor.writeOpenAPI(BaseProcessor.java:85)
        at io.avaje.http.generator.core.BaseProcessor.process(BaseProcessor.java:60)
        at org.jetbrains.jps.javac.APIWrappers$ProcessorWrapper.process(APIWrappers.java:109)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.jetbrains.jps.javac.APIWrappers$1.invoke(APIWrappers.java:213)
        at com.sun.proxy.$Proxy25.process(Unknown Source)
        at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:980)
        at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment$DiscoveredProcessors$ProcessorStateIterator.runContributingProcs(JavacProcessingEnvironment.java:816)
        at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.run(JavacProcessingEnvironment.java:1220)
        at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing(JavacProcessingEnvironment.java:1356)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.processAnnotations(JavaCompiler.java:1258)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:936)
        at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.lambda$doCall$0(JavacTaskImpl.java:104)
        at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.handleExceptions(JavacTaskImpl.java:147)
```
