### PR TITLE
Auto add exceptions

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/BadRequestResponse.java
+++ b/http-api/src/main/java/io/avaje/http/api/BadRequestResponse.java
@@ -1,13 +1,45 @@
 package io.avaje.http.api;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /*
  Extendable response class, if this class is extended it will be automatically added to the openapi json file.
  The default status code is 400 but can be changed with for example @StatusCode("404")
+
+ To register this response exception do:
+     javalin.exception(BadRequestResponse.class, (badRequestResponse, context) -> {
+        context.json(badRequestResponse.getResponse());
+        StatusCode statusCode = badRequestResponse.getClass().getAnnotation(StatusCode.class);
+        if(statusCode != null)
+            context.status(statusCode.value());
+        else
+            context.status(400);
+    });
  */
 public class BadRequestResponse extends Exception {
   public final String message;
 
   protected BadRequestResponse(String message) {
     this.message = message;
+  }
+
+  public Map<String, Object> getResponse() {
+    Field[] fields = this.getClass().getFields();
+    Map<String, Object> map = new LinkedHashMap<>();
+    for(Field field: fields){
+      if(!Modifier.isPublic(field.getModifiers()))
+        continue;
+
+      try {
+        map.put(field.getName(), field.get(this));
+      }
+      catch (IllegalAccessException e) {
+        e.printStackTrace();
+      }
+    }
+    return map;
   }
 }

--- a/http-api/src/main/java/io/avaje/http/api/BadRequestResponse.java
+++ b/http-api/src/main/java/io/avaje/http/api/BadRequestResponse.java
@@ -1,0 +1,13 @@
+package io.avaje.http.api;
+
+/*
+ Extendable response class, if this class is extended it will be automatically added to the openapi json file.
+ The default status code is 400 but can be changed with for example @StatusCode("404")
+ */
+public class BadRequestResponse extends Exception {
+  public final String message;
+
+  protected BadRequestResponse(String message) {
+    this.message = message;
+  }
+}

--- a/http-api/src/main/java/io/avaje/http/api/StatusCode.java
+++ b/http-api/src/main/java/io/avaje/http/api/StatusCode.java
@@ -28,5 +28,5 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(value=TYPE)
 @Retention(value=RUNTIME)
 public @interface StatusCode {
-  String value();
+  int value();
 }

--- a/http-api/src/main/java/io/avaje/http/api/StatusCode.java
+++ b/http-api/src/main/java/io/avaje/http/api/StatusCode.java
@@ -1,0 +1,32 @@
+package io.avaje.http.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specify the status code for a thrown exception
+ *
+ * <pre>{@code
+ *
+ *  @StatusCode("/customers")
+ *  class CustomerController extends BadRequestResponse {
+ *    ...
+ *  }
+ *
+ * }</pre>
+ *
+ * <h4>JAX-RS note</h4>
+ * <p>
+ * It should only be used on exceptions that extend BadRequestResponse
+ * Other exceptions won't be added to the swagger documentation
+ * </p>
+ */
+
+@Target(value=TYPE)
+@Retention(value=RUNTIME)
+public @interface StatusCode {
+  String value();
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
@@ -7,6 +7,7 @@ import io.avaje.http.api.Patch;
 import io.avaje.http.api.Post;
 import io.avaje.http.api.Produces;
 import io.avaje.http.api.Put;
+import io.avaje.http.api.BadRequestResponse;
 import io.avaje.http.generator.core.javadoc.Javadoc;
 import io.avaje.http.generator.core.openapi.MethodDocBuilder;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tags;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -202,6 +204,20 @@ public class MethodReader {
 
   public String getProduces() {
     return produces;
+  }
+
+  public List<DeclaredType> getBadRequestResponses() {
+    List<DeclaredType> thrownTypes = new ArrayList<>();
+
+    for(TypeMirror thrownType : element.getThrownTypes()) {
+      if (thrownType.getKind() == TypeKind.DECLARED) {
+        DeclaredType declaredType = (DeclaredType) thrownType;
+        if(ctx.isChildType(declaredType, BadRequestResponse.class)) {
+          thrownTypes.add(declaredType);
+        }
+      }
+    }
+    return thrownTypes;
   }
 
   public TypeMirror getReturnType() {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
@@ -212,11 +212,13 @@ public class MethodReader {
     for(TypeMirror thrownType : element.getThrownTypes()) {
       if (thrownType.getKind() == TypeKind.DECLARED) {
         DeclaredType declaredType = (DeclaredType) thrownType;
-        if(ctx.isChildType(declaredType, BadRequestResponse.class)) {
+
+        if(ctx.isChildOrSameType(declaredType, BadRequestResponse.class)) {
           thrownTypes.add(declaredType);
         }
       }
     }
+
     return thrownTypes;
   }
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -5,10 +5,10 @@ import io.avaje.http.generator.core.openapi.DocContext;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -50,6 +50,23 @@ public class ProcessingContext {
 
   public void logError(Element e, String msg, Object... args) {
     messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
+  }
+
+  public boolean isChildType(DeclaredType declaredType, Class superClass) {
+    TypeMirror superMirror = getTypeElement(superClass.getName()).asType();
+    for (TypeMirror supertype : types.directSupertypes(declaredType)) {
+      if(supertype.getKind() != TypeKind.DECLARED)
+        continue;
+
+      if(isSameType(superMirror, ((DeclaredType)supertype).asElement().asType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean isSameType(TypeMirror a, TypeMirror b) {
+    return types.isSameType(a, b);
   }
 
   /**

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -58,15 +58,11 @@ public class ProcessingContext {
       if(supertype.getKind() != TypeKind.DECLARED)
         continue;
 
-      if(isSameType(superMirror, ((DeclaredType)supertype).asElement().asType())) {
+      if(types.isSameType(superMirror, ((DeclaredType)supertype).asElement().asType())) {
         return true;
       }
     }
     return false;
-  }
-
-  public boolean isSameType(TypeMirror a, TypeMirror b) {
-    return types.isSameType(a, b);
   }
 
   /**

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -52,8 +52,12 @@ public class ProcessingContext {
     messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
   }
 
-  public boolean isChildType(DeclaredType declaredType, Class superClass) {
+  public boolean isChildOrSameType(DeclaredType declaredType, Class superClass) {
     TypeMirror superMirror = getTypeElement(superClass.getName()).asType();
+    if(types.isSameType(superMirror, declaredType)) {
+      return true;
+    }
+
     for (TypeMirror supertype : types.directSupertypes(declaredType)) {
       if(supertype.getKind() != TypeKind.DECLARED)
         continue;

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodDocBuilder.java
@@ -99,7 +99,7 @@ public class MethodDocBuilder {
 
       StatusCode statusCode = badRequestResponse.asElement().getAnnotation(StatusCode.class);
       if(statusCode != null)
-        apiResponses.addApiResponse(statusCode.value(), badRequestApiResponse);
+        apiResponses.addApiResponse(Integer.toString(statusCode.value()), badRequestApiResponse);
       else
         apiResponses.addApiResponse("400", badRequestApiResponse);
     }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
@@ -214,6 +214,9 @@ class SchemaDocBuilder {
   private <T> void populateObjectSchema(TypeMirror objectType, Schema<T> objectSchema) {
     Element element = types.asElement(objectType);
     for (VariableElement field : allFields(element)) {
+      if(! field.getModifiers().contains(Modifier.PUBLIC))
+        continue;
+
       Schema<?> propSchema = toSchema(field.asType());
       if (isNotNullable(field)) {
         propSchema.setNullable(Boolean.FALSE);


### PR DESCRIPTION
Hi Rob,

I have added something what could be a nice feature.
Auto adding a 404 status result for example in the openapi json file.

When you create an exception like this

    package com.example;
    
    import io.avaje.http.api.BadRequestResponse;
    import io.avaje.http.api.StatusCode;
    
    @StatusCode(505)
    public class ExampleErrorResponse extends BadRequestResponse {
      public int example= 1;
    
      public ExampleErrorResponse (String message) {
          super(message);
      }
    }

Then add it to a method like this:
     @Post
     public void updateExamplePost() throws ExampleErrorResponse

It will add it to the openapi with statuscode 505

Then to return these errors with the correct error code it should also be registered with the javalin service like this:

        javalin.exception(BadRequestResponse.class, (badRequestResponse, context) -> {
            context.json(badRequestResponse.getResponse());
            StatusCode statusCode = badRequestResponse.getClass().getAnnotation(StatusCode.class);
            if(statusCode != null)
                context.status(statusCode.value());
            else
                context.status(400);
        });


Hopefully you think it is a useful feature because I think it is quite handy to register fails also in the openapi documentation.

There are a few items left (or at least a few items)
- I do not know if the tests still run I cannot run them on my machine.
- I do not now if you can register the throwable exceptions the same way in helidon, jex etc because I have no experience with them.
- Not sure if Kotlin has the same way of throwing error so also not sure if this works

Tijs

