### PR TITLE
Now we can find controllers in other jar files / merging openapi.json

### DIFF
--- a/http-generator-core/pom.xml
+++ b/http-generator-core/pom.xml
@@ -53,7 +53,11 @@
       <artifactId>swagger-annotations</artifactId>
       <version>${swagger.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.12</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseControllerReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseControllerReader.java
@@ -1,0 +1,52 @@
+package io.avaje.http.generator.core;
+
+import io.avaje.http.api.Path;
+import io.avaje.http.api.Produces;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/*
+ B = Either Class or TypeElement, for Bean
+ I = Either Class or Element, for interfaces
+ M = Either Method or ExecutableElement for interfaceMethods
+ */
+public abstract class BaseControllerReader<B, I, M> {
+  /**
+   * The produces media type for the controller. Null implies JSON.
+   */
+  private final String produces;
+  protected final ProcessingContext ctx;
+  protected final B beanType;
+  protected final List<I> interfaces;
+  protected final List<M> interfaceMethods;
+
+  BaseControllerReader(B beanType, ProcessingContext ctx) {
+    this.beanType = beanType;
+    this.ctx = ctx;
+    this.interfaces = initInterfaces();
+    this.interfaceMethods = initInterfaceMethods();
+    this.produces = initProduces();
+  }
+
+  public abstract <A extends Annotation> A findAnnotation(Class<A> type);
+  protected abstract List<I> initInterfaces();
+  protected abstract List<M> initInterfaceMethods();
+
+  private String initProduces() {
+    final Produces produces = findAnnotation(Produces.class);
+    return (produces == null) ? null : produces.value();
+  }
+
+  public String getPath() {
+    Path path = findAnnotation(Path.class);
+    if (path == null) {
+      return null;
+    }
+    return Util.trimPath(path.value());
+  }
+
+  String getProduces() {
+    return produces;
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseElementReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseElementReader.java
@@ -1,0 +1,162 @@
+package io.avaje.http.generator.core;
+
+import io.avaje.http.api.*;
+import io.avaje.http.generator.core.openapi.MethodDocBuilder;
+
+import java.lang.annotation.Annotation;
+
+public abstract class BaseElementReader<E> {
+
+  protected final E element;
+  protected final String varName;
+  protected final String rawType;
+  protected final String snakeName;
+  protected final ProcessingContext ctx;
+  protected final TypeHandler typeHandler;
+  protected final String shortType;
+  protected final boolean formMarker;
+  protected final boolean contextType;
+
+  protected boolean notNullKotlin;
+  //protected boolean notNullJavax;
+
+  protected String paramDefault;
+  protected ParamType paramType;
+  protected String paramName;
+  protected boolean impliedParamType;
+
+  BaseElementReader(E element, String rawType, String varName, ProcessingContext ctx,  ParamType defaultType, boolean formMarker) {
+    this.element = element;
+    this.varName = varName;
+    this.paramName = varName;
+    this.rawType = rawType;
+    this.snakeName = Util.snakeCase(varName);
+    this.formMarker = formMarker;
+    this.typeHandler = TypeMap.get(rawType);
+    this.shortType = Util.shortName(rawType);
+    this.ctx = ctx;
+
+    this.contextType = ctx.platform().isContextType(rawType);
+
+    if (!contextType) {
+      readAnnotations(defaultType);
+    } else {
+      paramType = ParamType.CONTEXT;
+    }
+  }
+
+  /**
+   * Build the OpenAPI documentation for this parameter.
+   */
+  abstract void buildApiDocumentation(MethodDocBuilder methodDoc);
+
+  public abstract <A extends Annotation> A findAnnotation(Class<A> type);
+
+  protected String shortType() {
+    if (typeHandler != null) {
+      return typeHandler.shortName();
+    } else {
+      return shortType;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return varName + " type:" + rawType + " paramType:" + paramType + " dft:" + paramDefault;
+  }
+
+  public String getVarName() {
+    return varName;
+  }
+
+  public ParamType getParamType() {
+    return paramType;
+  }
+
+  public String getParamName() { return paramName; }
+
+  public String getShortType() {
+    return shortType;
+  }
+
+  public String getRawType() {
+    return rawType;
+  }
+
+  public E getElement() {
+    return element;
+  }
+
+  private void readAnnotations(ParamType defaultType) {
+    notNullKotlin = (findAnnotation(org.jetbrains.annotations.NotNull.class) != null);
+    //notNullJavax = (element.getAnnotation(javax.validation.constraints.NotNull.class) != null);
+
+    Default defaultVal = findAnnotation(Default.class);
+    if (defaultVal != null) {
+      this.paramDefault = defaultVal.value();
+    }
+
+    Form form = findAnnotation(Form.class);
+    if (form != null) {
+      this.paramType = ParamType.FORM;
+      return;
+    }
+
+    BeanParam beanParam = findAnnotation(BeanParam.class);
+    if (beanParam != null) {
+      this.paramType = ParamType.BEANPARAM;
+      return;
+    }
+
+    QueryParam queryParam = findAnnotation(QueryParam.class);
+    if (queryParam != null) {
+      this.paramName = nameFrom(queryParam.value(), varName);
+      this.paramType = ParamType.QUERYPARAM;
+      return;
+    }
+
+    FormParam formParam = findAnnotation(FormParam.class);
+    if (formParam != null) {
+      this.paramName = nameFrom(formParam.value(), varName);
+      this.paramType = ParamType.FORMPARAM;
+      return;
+    }
+
+    Cookie cookieParam = findAnnotation(Cookie.class);
+    if (cookieParam != null) {
+      this.paramName = nameFrom(cookieParam.value(), varName);
+      this.paramType = ParamType.COOKIE;
+      this.paramDefault = null;
+      return;
+    }
+
+    Header headerParam = findAnnotation(Header.class);
+    if (headerParam != null) {
+      this.paramName = nameFrom(headerParam.value(), Util.initcapSnake(snakeName));
+      this.paramType = ParamType.HEADER;
+      this.paramDefault = null;
+      return;
+    }
+
+    if (paramType == null) {
+      this.impliedParamType = true;
+      if (typeHandler != null) {
+        // a scalar type that we know how to convert
+        this.paramType = defaultType;
+      } else {
+        this.paramType = formMarker ? ParamType.FORM : ParamType.BODY;
+      }
+    }
+  }
+
+  private String nameFrom(String name, String defaultName) {
+    if (name != null && !name.isEmpty()) {
+      return name;
+    }
+    return defaultName;
+  }
+
+  protected boolean isPlatformContext() {
+    return contextType;
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseMethodParam.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseMethodParam.java
@@ -1,0 +1,31 @@
+package io.avaje.http.generator.core;
+
+import io.avaje.http.generator.core.openapi.MethodDocBuilder;
+
+public abstract class BaseMethodParam<B extends BaseElementReader> {
+  protected final B elementParam;
+
+  BaseMethodParam(B elementParam) {
+    this.elementParam = elementParam;
+  }
+
+  public boolean isBody() {
+    return elementParam.getParamType() == ParamType.BODY;
+  }
+
+  public boolean isForm() {
+    return elementParam.getParamType() == ParamType.FORM;
+  }
+
+  public String getShortType() {
+    return elementParam.getShortType();
+  }
+
+  public String getName() {
+    return elementParam.getVarName();
+  }
+
+  public void buildApiDocumentation(MethodDocBuilder methodDoc) {
+    elementParam.buildApiDocumentation(methodDoc);
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseMethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseMethodReader.java
@@ -1,0 +1,120 @@
+package io.avaje.http.generator.core;
+
+import io.avaje.http.api.*;
+import io.avaje.http.generator.core.javadoc.Javadoc;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+
+// All methods needed to generate openapi documentation
+public abstract class BaseMethodReader<X extends BaseControllerReader,T, P extends BaseMethodParam> {
+
+  protected final ProcessingContext ctx;
+  protected final X bean;
+  protected final boolean isVoid;
+  protected boolean formMarker;
+  protected WebMethod webMethod;
+  protected String webMethodPath;
+  protected final PathSegments pathSegments;
+  protected final String produces;
+  protected final T element;
+  protected List<P> params = new ArrayList<>();
+
+  public abstract Javadoc getJavadoc();
+  public abstract List<String> getTags();
+  public abstract  <A extends Annotation> A findAnnotation(Class<A> type);
+  public abstract void buildApiDocumentation(ProcessingContext ctx);
+
+  public BaseMethodReader(X bean, T element, boolean isVoid, ProcessingContext ctx) {
+    this.bean = bean;
+    this.element = element;
+    this.ctx = ctx;
+    this.isVoid = isVoid;
+
+    initWebMethodViaAnnotation();
+    if (isWebMethod()) {
+      this.pathSegments = PathSegments.parse(Util.combinePath(bean.getPath(), webMethodPath));
+    } else {
+      this.pathSegments = null;
+    }
+    this.produces = produces(bean);
+  }
+
+  public List<P> getParams() {
+    return params;
+  }
+
+  private String produces(BaseControllerReader bean) {
+    final Produces produces = findAnnotation(Produces.class);
+    return (produces != null) ? produces.value() : bean.getProduces();
+  }
+
+  private void initWebMethodViaAnnotation() {
+    Form form = findAnnotation(Form.class);
+    if (form != null) {
+      this.formMarker = true;
+    }
+    Get get = findAnnotation(Get.class);
+    if (get != null) {
+      initSetWebMethod(WebMethod.GET, get.value());
+      return;
+    }
+    Put put = findAnnotation(Put.class);
+    if (put != null) {
+      initSetWebMethod(WebMethod.PUT, put.value());
+      return;
+    }
+    Post post = findAnnotation(Post.class);
+    if (post != null) {
+      initSetWebMethod(WebMethod.POST, post.value());
+      return;
+    }
+    Patch patch = findAnnotation(Patch.class);
+    if (patch != null) {
+      initSetWebMethod(WebMethod.PATCH, patch.value());
+      return;
+    }
+    Delete delete = findAnnotation(Delete.class);
+    if (delete != null) {
+      initSetWebMethod(WebMethod.DELETE, delete.value());
+    }
+  }
+
+  private void initSetWebMethod(WebMethod webMethod, String value) {
+    this.webMethod = webMethod;
+    this.webMethodPath = value;
+  }
+
+  public boolean isWebMethod() { return webMethod != null; }
+
+  public String getFullPath() {
+    return pathSegments.fullPath();
+  }
+
+  public WebMethod getWebMethod() {
+    return webMethod;
+  }
+
+  public String getStatusCode() {
+    return Integer.toString(webMethod.statusCode(isVoid));
+  }
+
+  public boolean isVoid() {
+    return isVoid;
+  }
+
+  public String getProduces() {
+    return produces;
+  }
+
+  public void buildApiDoc() {
+    buildApiDocumentation(ctx);
+  }
+
+  protected ParamType defaultParamType() {
+    // non-path parameters default to form or query parameters based on the
+    // existence of @Form annotation on the method
+    return (formMarker) ? ParamType.FORMPARAM : ParamType.QUERYPARAM;
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerClassReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerClassReader.java
@@ -1,0 +1,118 @@
+package io.avaje.http.generator.core;
+
+import io.avaje.http.api.Path;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ControllerClassReader extends BaseControllerReader<Class, Class, Method> {
+  private final List<MethodClassReader> methods = new ArrayList<>();
+
+  public ControllerClassReader(Class<?> beanType, ProcessingContext ctx) {
+    super(beanType, ctx);
+  }
+
+  protected List<Method> initInterfaceMethods() {
+    List<Method> ifaceMethods = new ArrayList<>();
+    for (Class anInterface : interfaces) {
+      ifaceMethods.addAll(Arrays.asList(anInterface.getMethods()));
+    }
+    return ifaceMethods;
+  }
+
+  protected List<Class> initInterfaces() {
+    List<Class> interfaces = new ArrayList<>();
+    for (Class anInterface : beanType.getInterfaces()) {
+      if (anInterface.getAnnotation(Path.class) != null) {
+        interfaces.add(anInterface);
+      }
+    }
+    return interfaces;
+  }
+
+  void read() {
+    for (Method method : beanType.getMethods()) {
+      readMethod(method);
+    }
+    readSuper(beanType.getSuperclass());
+  }
+
+  /**
+   * Read methods from superclasses taking into account generics.
+   */
+  private void readSuper(Class<?> superClass) {
+    if( superClass == null)
+      return;
+    if ("java.lang.Object".equals(superClass.toString()))
+      return;
+
+    for (Method method : superClass.getMethods())
+      readMethod(method);
+    readSuper(superClass.getSuperclass());
+  }
+
+  private void readMethod(Method method) {
+    MethodClassReader methodReader = new MethodClassReader(this, method, ctx);
+    if (methodReader.isWebMethod()) {
+      methodReader.read();
+      methods.add(methodReader);
+    }
+  }
+
+  <A extends Annotation> A findMethodAnnotation(Class<A> type, Method method) {
+    for (Method interfaceMethod : interfaceMethods) {
+      if (matchMethod(interfaceMethod, method)) {
+        final A annotation = interfaceMethod.getAnnotation(type);
+        if (annotation != null) {
+          return annotation;
+        }
+      }
+    }
+    return null;
+  }
+
+  private boolean matchMethod(Method interfaceMethod, Method method) {
+    return interfaceMethod.toString().equals(method.toString());
+  }
+
+  public List<String> getTags() {
+    List<String> tags = new ArrayList<>();
+    if (beanType == null)
+      return tags;
+
+    if (beanType.getAnnotation(Tag.class) != null) {
+      tags.add(((Tag)beanType.getAnnotation(Tag.class)).name());
+    }
+    if (beanType.getAnnotation(Tags.class) != null) {
+      for (Tag tag : ((Tags)beanType.getAnnotation(Tags.class)).value())
+        tags.add(tag.name());
+    }
+    return tags;
+  }
+
+  @Override
+  public <A extends Annotation> A findAnnotation(Class<A> type) {
+    Annotation annotation = beanType.getAnnotation(type);
+    if (annotation != null) {
+      return (A) annotation;
+    }
+    for (Class anInterface : interfaces) {
+      annotation = anInterface.getAnnotation(type);
+      if (annotation != null) {
+        return (A) annotation;
+      }
+    }
+    return null;
+  }
+
+  void buildApiDocumentation(){
+    for(MethodClassReader methodClassReader: methods) {
+      methodClassReader.buildApiDocumentation(ctx);
+    }
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ElementClassReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ElementClassReader.java
@@ -1,0 +1,32 @@
+package io.avaje.http.generator.core;
+
+import io.avaje.http.generator.core.openapi.MethodDocBuilder;
+import io.avaje.http.generator.core.openapi.MethodParamClassDocBuilder;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Parameter;
+
+public class ElementClassReader extends BaseElementReader<Parameter> {
+
+  ElementClassReader(Parameter element, ProcessingContext ctx, ParamType defaultType, boolean formMarker) {
+    super(
+      element,
+      element.getType().getName(),
+      element.getName(),
+      ctx,
+      defaultType,
+      formMarker
+    );
+  }
+
+  @Override
+  void buildApiDocumentation(MethodDocBuilder methodDoc) {
+    if (!isPlatformContext()) {
+      new MethodParamClassDocBuilder(methodDoc, this).build();
+    }
+  }
+
+  @Override
+  public <A extends Annotation> A findAnnotation(Class<A> type) {
+    return null;
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodClassParam.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodClassParam.java
@@ -1,0 +1,16 @@
+package io.avaje.http.generator.core;
+
+import java.lang.reflect.Parameter;
+
+public class MethodClassParam extends BaseMethodParam<ElementClassReader> {
+  MethodClassParam(Parameter parameter, ProcessingContext ctx, ParamType defaultType, boolean formMarker) {
+    super(
+      new ElementClassReader(
+        parameter,
+        ctx,
+        defaultType,
+        formMarker
+      )
+    );
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodClassReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodClassReader.java
@@ -1,0 +1,72 @@
+package io.avaje.http.generator.core;
+
+import io.avaje.http.generator.core.javadoc.Javadoc;
+import io.avaje.http.generator.core.openapi.MethodDocBuilder;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MethodClassReader extends BaseMethodReader<ControllerClassReader, Method, MethodClassParam> {
+  public MethodClassReader(ControllerClassReader controllerClassReader, Method method, ProcessingContext ctx) {
+    super(controllerClassReader, method, method.getReturnType().equals(Void.TYPE), ctx);
+  }
+
+  @Override
+  public Javadoc getJavadoc() {
+    return Javadoc.parse("");
+  }
+
+  @Override
+  public <A extends Annotation> A findAnnotation(Class<A> type) {
+    A annotation = element.getAnnotation(type);
+    if (annotation != null) {
+      return annotation;
+    }
+
+    return bean.findMethodAnnotation(type, element);
+  }
+
+  @Override
+  public List<String> getTags() {
+    List<String> tags = new ArrayList<>();
+    if (element == null)
+      return tags;
+
+    if (element.getAnnotation(Tag.class) != null) {
+      tags.add(element.getAnnotation(Tag.class).name());
+    }
+    if (element.getAnnotation(Tags.class) != null) {
+      for (Tag tag : element.getAnnotation(Tags.class).value())
+        tags.add(tag.name());
+    }
+
+    tags.addAll(bean.getTags());
+    return tags;
+  }
+
+  public ParameterizedType getReturnType() {
+    if(element.getGenericReturnType() instanceof ParameterizedType)
+      return (ParameterizedType) element.getGenericReturnType();
+    return null;
+  }
+
+  public Class<?> getReturnClass() {
+    return element.getReturnType();
+  }
+
+  void read() {
+    for (Parameter parameter: element.getParameters()) {
+      params.add(new MethodClassParam(parameter, ctx, defaultParamType(), formMarker));
+    }
+  }
+
+  public void buildApiDocumentation(ProcessingContext ctx) {
+    new MethodDocBuilder(this, ctx.doc()).build();
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodParam.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodParam.java
@@ -1,15 +1,10 @@
 package io.avaje.http.generator.core;
 
-import io.avaje.http.generator.core.openapi.MethodDocBuilder;
-
 import javax.lang.model.element.VariableElement;
 
-public class MethodParam {
-
-  private final ElementReader elementParam;
-
+public class MethodParam extends BaseMethodParam<ElementReader>{
   MethodParam(VariableElement param, String rawType, ProcessingContext ctx, ParamType defaultParamType, boolean formMarker) {
-    this.elementParam = new ElementReader(param, rawType, ctx, defaultParamType, formMarker);
+    super(new ElementReader(param, rawType, ctx, defaultParamType, formMarker));
   }
 
   public void writeCtxGet(Append writer, PathSegments segments) {
@@ -27,25 +22,4 @@ public class MethodParam {
   public void buildParamName(Append writer) {
     elementParam.writeParamName(writer);
   }
-
-  public void buildApiDocumentation(MethodDocBuilder methodDoc) {
-    elementParam.buildApiDocumentation(methodDoc);
-  }
-
-  public boolean isBody() {
-    return elementParam.getParamType() == ParamType.BODY;
-  }
-
-  public boolean isForm() {
-    return elementParam.getParamType() == ParamType.FORM;
-  }
-
-  public String getShortType() {
-    return elementParam.getShortType();
-  }
-
-  public String getName() {
-    return elementParam.getVarName();
-  }
-
 }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -5,7 +5,6 @@ import io.avaje.http.generator.core.openapi.DocContext;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/BaseMethodParamDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/BaseMethodParamDocBuilder.java
@@ -1,0 +1,66 @@
+package io.avaje.http.generator.core.openapi;
+
+import io.avaje.http.generator.core.BaseElementReader;
+import io.avaje.http.generator.core.ParamType;
+import io.avaje.http.generator.core.javadoc.Javadoc;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+
+/**
+ * Build the OpenAPI for a method parameter.
+ */
+public abstract class BaseMethodParamDocBuilder<T> {
+
+  protected final DocContext ctx;
+  private final Javadoc javadoc;
+  private final Operation operation;
+  private final String paramName;
+  private final String varName;
+
+  private final ParamType paramType;
+  protected final T element;
+
+  public BaseMethodParamDocBuilder(MethodDocBuilder methodDoc, BaseElementReader param, T element) {
+    this.ctx = methodDoc.getContext();
+    this.javadoc = methodDoc.getJavadoc();
+    this.operation = methodDoc.getOperation();
+    this.paramType = param.getParamType();
+    this.paramName = param.getParamName();
+    this.varName = param.getVarName();
+    this.element = element;
+  }
+
+  /**
+   * Build the OpenAPI documentation for the method parameter.
+   */
+  public void build() {
+    if (paramType == ParamType.FORM || paramType == ParamType.BODY) {
+      addMetaRequestBody(ctx, javadoc, operation);
+    } else {
+      Parameter param = new Parameter();
+      param.setName(varName);
+      param.setDescription(javadoc.getParams().get(paramName));
+
+      Schema schema = getSchema();
+      if (paramType == ParamType.FORMPARAM) {
+        ctx.addFormParam(operation, varName, schema);
+
+      } else {
+        param.setSchema(schema);
+        param.setIn(paramType.getType());
+        operation.addParametersItem(param);
+      }
+    }
+  }
+
+  protected abstract Schema getSchema();
+
+  private void addMetaRequestBody(DocContext ctx, Javadoc javadoc, Operation operation) {
+    Schema schema = getSchema();
+    String description = javadoc.getParams().get(paramName);
+
+    boolean asForm = (paramType == ParamType.FORM);
+    ctx.addRequestBody(operation, schema, asForm, description);
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/KnownTypes.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/KnownTypes.java
@@ -42,6 +42,8 @@ class KnownTypes {
     add(new StringType(), String.class, char[].class, CharSequence.class);
     add(new BoolType(), boolean.class);
     add(new BooleanType(), Boolean.class);
+    add(new ShortType(), Short.class);
+    add(new PShortType(), short.class);
     add(new IntType(), int.class);
     add(new IntegerType(), Integer.class);
     add(new PLongType(), long.class);
@@ -98,6 +100,16 @@ class KnownTypes {
     public Schema<?> createSchema() {
       return new BooleanSchema();
     }
+  }
+
+  private class ShortType implements KnownType {
+    @Override
+    public Schema<?> createSchema() { return new IntegerSchema().minimum(new BigDecimal(Short.MIN_VALUE)).maximum(new BigDecimal(Short.MAX_VALUE)); }
+  }
+
+  private class PShortType implements KnownType {
+    @Override
+    public Schema<?> createSchema() { return new IntegerSchema().minimum(new BigDecimal(Short.MIN_VALUE)).maximum(new BigDecimal(Short.MAX_VALUE)).nullable(Boolean.FALSE); }
   }
 
   private class IntType implements KnownType {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodParamClassDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodParamClassDocBuilder.java
@@ -1,0 +1,25 @@
+package io.avaje.http.generator.core.openapi;
+
+import io.avaje.http.generator.core.ElementClassReader;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.lang.reflect.Parameter;
+
+/**
+ * Build the OpenAPI for a method parameter.
+ */
+public class MethodParamClassDocBuilder extends BaseMethodParamDocBuilder<Parameter> {
+
+  public MethodParamClassDocBuilder(MethodDocBuilder methodDoc, ElementClassReader param) {
+    super(
+      methodDoc,
+      param,
+      param.getElement()
+    );
+  }
+
+  @Override
+  protected Schema getSchema() {
+    return ctx.toSchema(this.element);
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodParamDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodParamDocBuilder.java
@@ -1,73 +1,28 @@
 package io.avaje.http.generator.core.openapi;
 
 import io.avaje.http.generator.core.ElementReader;
-import io.avaje.http.generator.core.ParamType;
-import io.avaje.http.generator.core.javadoc.Javadoc;
-import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.parameters.Parameter;
 
 import javax.lang.model.element.Element;
 
 /**
  * Build the OpenAPI for a method parameter.
  */
-public class MethodParamDocBuilder {
+public class MethodParamDocBuilder extends BaseMethodParamDocBuilder<Element> {
 
-  private final DocContext ctx;
-  private final Javadoc javadoc;
-  private final Operation operation;
-  private final String paramName;
-  private final String varName;
   private final String rawType;
-  private final ParamType paramType;
-  private final Element element;
 
   public MethodParamDocBuilder(MethodDocBuilder methodDoc, ElementReader param) {
-
-    this.ctx = methodDoc.getContext();
-    this.javadoc = methodDoc.getJavadoc();
-    this.operation = methodDoc.getOperation();
-
-    this.paramType = param.getParamType();
-    this.paramName = param.getParamName();
-    this.varName = param.getVarName();
+    super(
+      methodDoc,
+      param,
+      param.getElement()
+    );
     this.rawType = param.getRawType();
-    this.element = param.getElement();
   }
 
-  /**
-   * Build the OpenAPI documentation for the method parameter.
-   */
-  public void build() {
-
-    if (paramType == ParamType.FORM || paramType == ParamType.BODY) {
-      addMetaRequestBody(ctx, javadoc, operation);
-
-    } else {
-      Parameter param = new Parameter();
-      param.setName(varName);
-      param.setDescription(javadoc.getParams().get(paramName));
-
-      Schema schema = ctx.toSchema(rawType, element);
-      if (paramType == ParamType.FORMPARAM) {
-        ctx.addFormParam(operation, varName, schema);
-
-      } else {
-        param.setSchema(schema);
-        param.setIn(paramType.getType());
-        operation.addParametersItem(param);
-      }
-    }
+  @Override
+  protected Schema getSchema() {
+    return ctx.toSchema(this.rawType, this.element);
   }
-
-  private void addMetaRequestBody(DocContext ctx, Javadoc javadoc, Operation operation) {
-
-    Schema schema = ctx.toSchema(rawType, element);
-    String description = javadoc.getParams().get(paramName);
-
-    boolean asForm = (paramType == ParamType.FORM);
-    ctx.addRequestBody(operation, schema, asForm, description);
-  }
-
 }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import static io.avaje.http.generator.core.Util.typeDef;
 
@@ -44,18 +43,14 @@ class SchemaDocBuilder {
   private final KnownTypes knownTypes;
   private final TypeMirror iterableType;
   private final TypeMirror mapType;
+  private final Map<String, Schema> schemas;
 
-  private final Map<String, Schema> schemas = new TreeMap<>();
-
-  SchemaDocBuilder(Types types, Elements elements) {
+  SchemaDocBuilder(Types types, Elements elements, Map<String, Schema> schemas) {
+    this.schemas = schemas;
     this.types = types;
     this.knownTypes = new KnownTypes();
     this.iterableType = types.erasure(elements.getTypeElement("java.lang.Iterable").asType());
     this.mapType = types.erasure(elements.getTypeElement("java.util.Map").asType());
-  }
-
-  Map<String, Schema> getSchemas() {
-    return schemas;
   }
 
   Content createContent(TypeMirror returnType, String mediaType) {
@@ -122,7 +117,6 @@ class SchemaDocBuilder {
   }
 
   Schema<?> toSchema(TypeMirror type) {
-
     Schema<?> schema = knownTypes.createSchema(typeDef(type));
     if (schema != null) {
       return schema;
@@ -160,7 +154,6 @@ class SchemaDocBuilder {
   }
 
   private Schema<?> buildIterableSchema(TypeMirror type) {
-
     Schema<?> itemSchema = new ObjectSchema().format("unknownIterableType");
 
     if (type.getKind() == TypeKind.DECLARED) {
@@ -176,7 +169,6 @@ class SchemaDocBuilder {
   }
 
   private Schema<?> buildArraySchema(TypeMirror type) {
-
     ArrayType arrayType = types.getArrayType(type);
     Schema<?> itemSchema = toSchema(arrayType.getComponentType());
 
@@ -186,7 +178,6 @@ class SchemaDocBuilder {
   }
 
   private Schema<?> buildMapSchema(TypeMirror type) {
-
     Schema<?> valueSchema = new ObjectSchema().format("unknownMapValueType");
 
     if (type.getKind() == TypeKind.DECLARED) {
@@ -211,7 +202,7 @@ class SchemaDocBuilder {
     return canonicalName;
   }
 
-  private <T> void populateObjectSchema(TypeMirror objectType, Schema<T> objectSchema) {
+  private <T> void populateObjectSchema(TypeMirror objectType, Schema<?> objectSchema) {
     Element element = types.asElement(objectType);
     for (VariableElement field : allFields(element)) {
       Schema<?> propSchema = toSchema(field.asType());
@@ -304,5 +295,4 @@ class SchemaDocBuilder {
     Set<Modifier> modifiers = field.getModifiers();
     return (modifiers.contains(Modifier.STATIC) || modifiers.contains(Modifier.TRANSIENT));
   }
-
 }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilderClass.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilderClass.java
@@ -1,0 +1,230 @@
+package io.avaje.http.generator.core.openapi;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.models.media.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Size;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+import java.util.*;
+
+/**
+ * Help build OpenAPI Schema objects.
+ */
+class SchemaDocBuilderClass {
+  private final KnownTypes knownTypes;
+  private final Map<String, Schema> schemas;
+
+  SchemaDocBuilderClass(Map<String, Schema> schemas) {
+    this.knownTypes = new KnownTypes();
+    this.schemas = schemas;
+  }
+
+  Schema<?> toSchema(Class theClass, Type theType) {
+    Schema<?> schema = knownTypes.createSchema(theClass.getCanonicalName());
+    if (schema != null) {
+      return schema;
+    }
+
+    if(AbstractMap.class.isAssignableFrom(theClass)) {
+      return buildMapSchema(theClass, theType);
+    }
+
+    if (Collection.class.isAssignableFrom(theClass)) {
+      return buildArraySchema(theType);
+    }
+    return buildObjectSchema(theClass);
+  }
+
+  private String getObjectSchemaName(Class type) {
+    String canonicalName = type.toString();
+    int pos = canonicalName.lastIndexOf('.');
+    if (pos > -1) {
+      canonicalName = canonicalName.substring(pos + 1);
+    }
+    return canonicalName;
+  }
+
+  private Schema<?> buildObjectSchema(Class object) {
+    String objectSchemaKey = getObjectSchemaName(object);
+
+    Schema objectSchema = schemas.get(objectSchemaKey);
+    if (objectSchema == null) {
+      // Put first to resolve recursive stack overflow
+      objectSchema = new ObjectSchema();
+      schemas.put(objectSchemaKey, objectSchema);
+      populateObjectSchema(object, objectSchema);
+    }
+
+    Schema ref = new Schema();
+    ref.$ref("#/components/schemas/" + objectSchemaKey);
+    return ref;
+  }
+
+  private <T> void populateObjectSchema(Class object, Schema<T> objectSchema) {
+    for (Field field: allFields(object)) {
+      ParameterizedType type = null;
+      if (field.getGenericType() instanceof ParameterizedType)
+        type = (ParameterizedType) field.getGenericType();
+
+      Schema<?> propSchema = toSchema(field.getType(), type);
+      if (isNotNullable(field)) {
+        propSchema.setNullable(Boolean.FALSE);
+      }
+      setLengthMinMax(field, propSchema);
+      setFormatFromValidation(field, propSchema);
+      objectSchema.addProperties(field.getName(), propSchema);
+    }
+  }
+
+  private void setFormatFromValidation(Field field, Schema<?> propSchema) {
+    if (field.getAnnotation(Email.class) != null) {
+      propSchema.setFormat("email");
+    }
+  }
+
+  Content createContent(Class returnType, ParameterizedType type, String mediaType) {
+    MediaType mt = new MediaType();
+    mt.setSchema(toSchema(returnType,type));
+    Content content = new Content();
+    content.addMediaType(mediaType, mt);
+    return content;
+  }
+
+  private void setLengthMinMax(Field field, Schema<?> propSchema) {
+    final Size size = field.getAnnotation(Size.class);
+    if (size != null) {
+      if (size.min() > 0) {
+        propSchema.setMinLength(size.min());
+      }
+      if (size.max() > 0) {
+        propSchema.setMaxLength(size.max());
+      }
+    }
+  }
+
+  /**
+   * Gather all the fields (properties) for the given bean element.
+   */
+  private List<Field> allFields(Class object) {
+    List<Field> list = new ArrayList<>();
+    gatherProperties(list, object);
+    return list;
+  }
+
+  /**
+   * Recursively gather all the fields (properties) for the given bean element.
+   */
+  private void gatherProperties(List<Field> fields, Class object) {
+    if (object == null) {
+      return;
+    }
+    Class mappedSuper = object.getSuperclass();
+    if (mappedSuper != null && !"java.lang.Object".equals(mappedSuper.toString())) {
+      gatherProperties(fields, mappedSuper);
+    }
+
+    for (Field field : object.getFields()) {
+      if (!ignoreField(field)) {
+        fields.add(field);
+      }
+    }
+  }
+
+  private Schema<?> buildArraySchema(Type type) {
+    ArraySchema arraySchema = new ArraySchema();
+    if(type == null || !(type instanceof ParameterizedType))
+      return arraySchema;
+
+    Type[] typeArguments = ((ParameterizedType)type).getActualTypeArguments();
+    if(typeArguments.length == 0)
+      return arraySchema;
+
+    Class parameterClass;
+    if (typeArguments[0] instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType)typeArguments[0];
+      parameterClass = getClassFromString(parameterizedType.getRawType().getTypeName());
+    }
+    else {
+      parameterClass = getClassFromString(typeArguments[0].getTypeName());
+    }
+
+    if(parameterClass == null)
+      return arraySchema;
+
+    Schema<?> itemSchema = toSchema(parameterClass, typeArguments[0]);
+    arraySchema.setItems(itemSchema);
+    return arraySchema;
+  }
+
+  private Class getClassFromString(String className) {
+    try {
+      return Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      System.out.println("Cannot convert " + className + " to class");
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  private Schema<?> buildMapSchema(Class<Map> map, Type type) {
+    MapSchema mapSchema = new MapSchema();
+
+    if(type == null || !(type instanceof ParameterizedType))
+      return mapSchema;
+
+    Type[] typeArguments = ((ParameterizedType)type).getActualTypeArguments();
+    if(typeArguments.length < 2)
+      return mapSchema;
+
+    Class parameterClass;
+    Type typeArgument = typeArguments[1];
+    if (typeArgument instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType)typeArgument;
+      parameterClass = getClassFromString(parameterizedType.getRawType().getTypeName());
+    }
+    else {
+      parameterClass = getClassFromString(typeArgument.getTypeName());
+    }
+
+    if(parameterClass == null)
+      return mapSchema;
+
+    mapSchema.setAdditionalProperties(toSchema(parameterClass, typeArgument));
+    return mapSchema;
+  }
+
+  /**
+   * Ignore static or transient fields.
+   */
+  private boolean ignoreField(Field field) {
+    return isStaticOrTransient(field) || isHiddenField(field);
+  }
+
+  private boolean isHiddenField(Field field) {
+
+    Hidden hidden = field.getAnnotation(Hidden.class);
+    if (hidden != null) {
+      return true;
+    }
+
+    for (Annotation annotation : field.getAnnotations()) {
+      String simpleName = annotation.annotationType().getSimpleName();
+      if ("JsonIgnore".equals(simpleName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isStaticOrTransient(Field field) {
+    int modifiers = field.getModifiers();
+    return (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers));
+  }
+
+  private boolean isNotNullable(Field field) {
+    return field.getAnnotation(org.jetbrains.annotations.NotNull.class) != null
+      || field.getAnnotation(javax.validation.constraints.NotNull.class) != null;
+  }
+}


### PR DESCRIPTION
I have tried something, it was a lot of work and I am not sure if it is a good thing but it works.
I now can locate controllers in other jar files and add them to the openapi.json file

So it could be a solution for #51 

But as I said it kind of is a large change on top of your code. It seems to work and I have compared the openapi.json that is created on a few types of parameters / returns types. With and without lists etc.

One thing that is also important to mention you need to add the following to your pom file to keep the parameter names so they can be used for generating the openapi.json file.

        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
                <compilerArgument>-parameters</compilerArgument>
                <source>${maven.compiler.source}</source>
                <target>${maven.compiler.target}</target>
                <parameters>true</parameters>
            </configuration>
        </plugin>

Please let me know if it could be something useful or not...
Tijs