### PR TITLE
Bump to avaje-inject 6.x with $Factory for request scoped controllers

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/Constants.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/Constants.java
@@ -1,6 +1,12 @@
 package io.avaje.http.generator.core;
 
-class Constants {
+public class Constants {
+
+  /**
+   * The suffix used by avaje-inject for generated factories.
+   * A factory is generated automatically for request scoped controllers.
+   */
+  public static final String FACTORY_SUFFIX = "$Factory";
 
   static final String OPENAPIDEFINITION = "io.swagger.v3.oas.annotations.OpenAPIDefinition";
 

--- a/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/ControllerWriter.java
+++ b/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/ControllerWriter.java
@@ -1,9 +1,6 @@
 package io.avaje.http.generator.helidon;
 
-import io.avaje.http.generator.core.BaseControllerWriter;
-import io.avaje.http.generator.core.ControllerReader;
-import io.avaje.http.generator.core.MethodReader;
-import io.avaje.http.generator.core.ProcessingContext;
+import io.avaje.http.generator.core.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -70,7 +67,7 @@ class ControllerWriter extends BaseControllerWriter {
     String controllerType = shortName;
     if (isRequestScoped()) {
       controllerName = "factory";
-      controllerType += "$factory";
+      controllerType += Constants.FACTORY_SUFFIX;
     }
     writer.append("  private final %s %s;", controllerType, controllerName).eol();
     if (reader.isIncludeValidator()) {

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
@@ -1,9 +1,6 @@
 package io.avaje.http.generator.javalin;
 
-import io.avaje.http.generator.core.BaseControllerWriter;
-import io.avaje.http.generator.core.ControllerReader;
-import io.avaje.http.generator.core.MethodReader;
-import io.avaje.http.generator.core.ProcessingContext;
+import io.avaje.http.generator.core.*;
 
 import java.io.IOException;
 
@@ -55,7 +52,7 @@ class ControllerWriter extends BaseControllerWriter {
     String controllerType = shortName;
     if (isRequestScoped()) {
       controllerName = "factory";
-      controllerType += "$factory";
+      controllerType += Constants.FACTORY_SUFFIX;
     }
     writer.append("  private final %s %s;", controllerType, controllerName).eol();
 

--- a/http-generator-jex/src/main/java/io/avaje/http/generator/jex/ControllerWriter.java
+++ b/http-generator-jex/src/main/java/io/avaje/http/generator/jex/ControllerWriter.java
@@ -1,9 +1,6 @@
 package io.avaje.http.generator.jex;
 
-import io.avaje.http.generator.core.BaseControllerWriter;
-import io.avaje.http.generator.core.ControllerReader;
-import io.avaje.http.generator.core.MethodReader;
-import io.avaje.http.generator.core.ProcessingContext;
+import io.avaje.http.generator.core.*;
 
 import java.io.IOException;
 
@@ -57,7 +54,7 @@ class ControllerWriter extends BaseControllerWriter {
     String controllerType = shortName;
     if (isRequestScoped()) {
       controllerName = "factory";
-      controllerType += "$factory";
+      controllerType += Constants.FACTORY_SUFFIX;
     }
     writer.append("  private final %s %s;", controllerType, controllerName).eol();
 

--- a/http-generator-spark/src/main/java/io/avaje/http/generator/spark/ControllerWriter.java
+++ b/http-generator-spark/src/main/java/io/avaje/http/generator/spark/ControllerWriter.java
@@ -55,7 +55,7 @@ class ControllerWriter extends BaseControllerWriter {
     String controllerType = shortName;
     if (isRequestScoped()) {
       controllerName = "factory";
-      controllerType += "$factory";
+      controllerType += Constants.FACTORY_SUFFIX;
     }
     writer.append("  private final %s %s;", controllerType, controllerName).eol();
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <module>http-generator-jex</module>
     <module>http-generator-helidon</module>
     <module>http-generator-client</module>
-<!--    <module>tests</module>-->
+    <module>tests</module>
   </modules>
 
 </project>

--- a/tests/test-client/pom.xml
+++ b/tests/test-client/pom.xml
@@ -19,7 +19,7 @@
 <!--    <dependency>-->
 <!--      <groupId>io.avaje</groupId>-->
 <!--      <artifactId>avaje-http-generator-client</artifactId>-->
-<!--      <version>1.4-SNAPSHOT</version>-->
+<!--      <version>1.5-SNAPSHOT</version>-->
 <!--      <scope>provided</scope>-->
 <!--    </dependency>-->
 
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-client</artifactId>
-      <version>1.4-SNAPSHOT</version>
+      <version>1.4</version>
     </dependency>
 
     <dependency>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.4-SNAPSHOT</version>
+      <version>1.5-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -100,7 +100,7 @@
             <path>
               <groupId>io.avaje</groupId>
               <artifactId>avaje-http-generator-client</artifactId>
-              <version>1.4-SNAPSHOT</version>
+              <version>1.5-SNAPSHOT</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/tests/test-helidon/pom.xml
+++ b/tests/test-helidon/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <mainClass>org.example.Main</mainClass>
     <helidon-version>2.2.2</helidon-version>
-    <avaje-http-version>1.4-SNAPSHOT</avaje-http-version>
+    <avaje-http-version>1.5-SNAPSHOT</avaje-http-version>
   </properties>
 
   <dependencies>
@@ -36,17 +36,17 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>4.1</version>
+      <version>6.0.RC4</version>
     </dependency>
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject-generator</artifactId>
-      <version>4.1</version>
+      <version>6.0.RC4</version>
       <scope>provided</scope>
     </dependency>
 
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-client</artifactId>
-      <version>1.0</version>
+      <version>1.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/tests/test-helidon/src/test/java/org/example/BaseWebTest.java
+++ b/tests/test-helidon/src/test/java/org/example/BaseWebTest.java
@@ -28,7 +28,7 @@ public class BaseWebTest {
   public static HttpClientContext client() {
     return HttpClientContext.newBuilder()
       .withBaseUrl(baseUrl)
-      .withResponseListener(new RequestLogger())
+      .withRequestListener(new RequestLogger())
       .withBodyAdapter(new JacksonBodyAdapter(new ObjectMapper()))
       //.with(httpClient)
       .build();

--- a/tests/test-javalin/pom.xml
+++ b/tests/test-javalin/pom.xml
@@ -20,7 +20,7 @@
     <swagger.version>2.0.8</swagger.version>
     <kotlin.version>1.3.71</kotlin.version>
     <jackson.version>2.12.3</jackson.version>
-    <avaje-http-version>1.4-SNAPSHOT</avaje-http-version>
+    <avaje-http-version>1.5-SNAPSHOT</avaje-http-version>
   </properties>
 
   <dependencies>
@@ -52,19 +52,19 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>4.1</version>
+      <version>6.0.RC4</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>2.0</version>
+      <version>2.5</version>
     </dependency>
 
     <dependency>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject-generator</artifactId>
-      <version>4.1</version>
+      <version>6.0.RC4</version>
       <scope>provided</scope>
     </dependency>
 
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-client</artifactId>
-      <version>1.0</version>
+      <version>1.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/tests/test-javalin/src/test/java/org/example/myapp/BaseWebTest.java
+++ b/tests/test-javalin/src/test/java/org/example/myapp/BaseWebTest.java
@@ -28,7 +28,7 @@ public class BaseWebTest {
   public static HttpClientContext client() {
     return HttpClientContext.newBuilder()
       .withBaseUrl(baseUrl)
-      .withResponseListener(new RequestLogger())
+      .withRequestListener(new RequestLogger())
       .withBodyAdapter(new JacksonBodyAdapter(new ObjectMapper()))
       //.with(httpClient)
       .build();

--- a/tests/test-javalin/src/test/java/org/example/myapp/HelloControllerTest.java
+++ b/tests/test-javalin/src/test/java/org/example/myapp/HelloControllerTest.java
@@ -36,7 +36,7 @@ class HelloControllerTest extends BaseWebTest {
 
     this.clientContext = HttpClientContext.newBuilder()
       .withBaseUrl(baseUrl)
-      .withResponseListener(new RequestLogger())
+      .withRequestListener(new RequestLogger())
       .withBodyAdapter(new JacksonBodyAdapter(new ObjectMapper()))
       .with(httpClient)
       .build();

--- a/tests/test-jex/pom.xml
+++ b/tests/test-jex/pom.xml
@@ -19,8 +19,8 @@
     <jex.version>1.3</jex.version>
     <swagger.version>2.0.8</swagger.version>
     <jackson.version>2.12.3</jackson.version>
-    <avaje-inject.version>6.0.RC3</avaje-inject.version>
-    <avaje-http.version>1.4-SNAPSHOT</avaje-http.version>
+    <avaje-inject.version>6.0.RC4</avaje-inject.version>
+    <avaje-http.version>1.5-SNAPSHOT</avaje-http.version>
   </properties>
 
   <dependencies>
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-client</artifactId>
-      <version>1.1</version>
+      <version>1.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/tests/test-spark/pom.xml
+++ b/tests/test-spark/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <main.class>org.example.myapp.Main</main.class>
     <swagger.version>2.0.8</swagger.version>
-    <avaje-http-version>1.4-SNAPSHOT</avaje-http-version>
+    <avaje-http-version>1.5-SNAPSHOT</avaje-http-version>
   </properties>
 
   <dependencies>
@@ -43,19 +43,19 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>4.1</version>
+      <version>6.0.RC4</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>2.0</version>
+      <version>2.5</version>
     </dependency>
 
     <dependency>
@@ -69,14 +69,14 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject-generator</artifactId>
-      <version>4.1</version>
+      <version>6.0.RC4</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-spark-generator</artifactId>
-      <version>1.4-SNAPSHOT</version>
+      <version>1.5-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-client</artifactId>
-      <version>1.0</version>
+      <version>1.4</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
- Bumps to avaje-inject 6.x and $Factory
- Bumps avaje-http-hibernate-validator to 2.5
- Bumps http client used in tests