### PR TITLE
Now get Component Type from Array TypeMirror

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
@@ -177,7 +177,7 @@ class SchemaDocBuilder {
 
   private Schema<?> buildArraySchema(TypeMirror type) {
 
-    ArrayType arrayType = types.getArrayType(type);
+    ArrayType arrayType = (ArrayType) type;
     Schema<?> itemSchema = toSchema(arrayType.getComponentType());
 
     ArraySchema arraySchema = new ArraySchema();


### PR DESCRIPTION
Using  `types.getArrayType(type)` seems to convert an array TypeMirror object into a 2D array. e.g. `byte[]` -> `byte[][]`. So when the `getComponentType()` method is called the same base `byte[]` TypeMirror is returned, causing a loop. Fixes #89

Tested on this [Controller](https://github.com/SentryMan/Avaje-Javalin-API-Example/blob/df1359f7dee572e13bfe600c6e2d6756a400231e/src/main/java/com/jojo/javalin/api/controller/ControllerClass.java), which generates this [ControllerClass$Route.java](https://github.com/SentryMan/Avaje-Javalin-API-Example/blob/708f92abcf51ba63b2e46d31a5b8788bcb115b1d/ControllerClass%24Route.java) and [OpenAPI json](https://github.com/SentryMan/Avaje-Javalin-API-Example/blob/ed6fc66e41e201efb833176bee968776d459471c/openapi.json)
