### PR TITLE
Support generic jsonb types

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ If [Avaje-Jsonb](https://github.com/avaje/avaje-jsonb) is detected, http generat
 public class WidgetController$Route implements WebRoutes {
 
   private final WidgetController controller;
-  private final JsonType<java.util.List<org.example.hello.WidgetController.Widget>> listWidgetJsonType;
-  private final JsonType<org.example.hello.WidgetController.Widget> widgetJsonType;
+  private final JsonType<List<Widget>> listWidgetJsonType;
+  private final JsonType<Widget> widgetJsonType;
 
   public WidgetController$Route(WidgetController controller, Jsonb jsonB) {
     this.controller = controller;
-    this.listWidgetJsonType = jsonB.type(org.example.hello.WidgetController.Widget.class).list();
-    this.widgetJsonType = jsonB.type(org.example.hello.WidgetController.Widget.class);
+    this.listWidgetJsonType = jsonB.type(Widget.class).list();
+    this.widgetJsonType = jsonB.type(Widget.class);
   }
 
   @Override

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -139,7 +139,7 @@ class ClientMethodWriter {
     } else if (isHttpResponse(mainType)) {
       writeWithHandler();
     } else {
-      writer.append(".bean(").eol();
+      writer.append(".bean(");
       writeGeneric(type);
     }
   }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -34,12 +34,7 @@ class ClientMethodWriter {
   void addImportTypes(ControllerReader reader) {
     reader.addImportTypes(returnType.importTypes());
     for (final MethodParam param : method.params()) {
-      final var type = param.utype();
-      final var type0 = type.param0();
-      final var type1 = type.param1();
-      reader.addImportType(type.mainType().replace("[]", ""));
-      if (type0 != null) reader.addImportType(type0.replace("[]", ""));
-      if (type1 != null) reader.addImportType(type1.replace("[]", ""));
+      reader.addImportTypes(param.utype().importTypes());
     }
   }
 

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -4,6 +4,7 @@ import io.avaje.http.generator.core.*;
 
 import javax.lang.model.element.TypeElement;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Write code to register Web route for a given controller method.
@@ -22,13 +23,15 @@ class ClientMethodWriter {
   private final UType returnType;
   private MethodParam bodyHandlerParam;
   private String methodGenericParams = "";
+  private final boolean useJsonb;
 
-  ClientMethodWriter(MethodReader method, Append writer, ProcessingContext ctx) {
+  ClientMethodWriter(MethodReader method, Append writer, ProcessingContext ctx, boolean useJsonb) {
     this.method = method;
     this.writer = writer;
     this.webMethod = method.webMethod();
     this.ctx = ctx;
     this.returnType = Util.parseType(method.returnType());
+    this.useJsonb = useJsonb;
   }
 
   void addImportTypes(ControllerReader reader) {
@@ -111,35 +114,53 @@ class ClientMethodWriter {
 
   private void writeSyncResponse() {
     writer.append("      ");
-    String type0 = returnType.mainType();
-    String type1 = returnType.param0();
-    writeResponse(type0, type1);
+    writeResponse(returnType);
   }
 
   private void writeAsyncResponse() {
     writer.append("      .async()");
-    String type0 = returnType.param0();
-    String type1 = returnType.param1();
-    writeResponse(type0, type1);
+    writeResponse(UType.parse(returnType.param0()));
   }
 
   private void writeCallResponse() {
     writer.append("      .call()");
-    String type0 = returnType.param0();
-    String type1 = returnType.param1();
-    writeResponse(type0, type1);
+    writeResponse(UType.parse(returnType.param0()));
   }
 
-  private void writeResponse(String type0, String type1) {
-    if (isList(type0)) {
-      writer.append(".list(%s.class);", Util.shortName(type1)).eol();
-    } else if (isStream(type0)) {
-      writer.append(".stream(%s.class);", Util.shortName(type1)).eol();
-    } else if (isHttpResponse(type0)){
+  private void writeResponse(UType type) {
+    final var mainType = type.mainType();
+    final var param1 = type.paramRaw();
+    if (isList(mainType)) {
+      writer.append(".list(");
+      writeGeneric(UType.parse(param1));
+    } else if (isStream(mainType)) {
+      writer.append(".stream(");
+      writeGeneric(UType.parse(param1));
+    } else if (isHttpResponse(mainType)) {
       writeWithHandler();
     } else {
-      writer.append(".bean(%s.class);", Util.shortName(type0)).eol();
+      writer.append(".bean(", Util.shortName(mainType)).eol();
+      writeGeneric(type);
     }
+  }
+
+  void writeGeneric(UType type) {
+    if (useJsonb && type.isGeneric()) {
+      final var params =
+          type.importTypes().stream()
+                  .skip(1)
+                  .map(Util::shortName)
+                  .collect(Collectors.joining(".class, "))
+              + ".class";
+
+      writer.append(
+          "Types.newParameterizedType(%s.class, %s)", Util.shortName(type.mainType()), params);
+    } else {
+      writer.append("%s.class", Util.shortName(type.mainType()));
+    }
+    writer.append(");");
+
+    writer.eol();
   }
 
   private void writeWithHandler() {

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -27,6 +27,21 @@ public class ClientProcessor extends AbstractProcessor {
 
   protected ProcessingContext ctx;
 
+  private boolean useJsonB;
+
+  public ClientProcessor() {
+    try {
+      Class.forName("io.avaje.jsonb.Jsonb");
+      this.useJsonB = true;
+    } catch (final ClassNotFoundException e) {
+      this.useJsonB = false;
+    }
+  }
+
+  public ClientProcessor(boolean useJsonb) {
+    useJsonB = useJsonb;
+  }
+
   @Override
   public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latest();
@@ -107,7 +122,7 @@ public class ClientProcessor extends AbstractProcessor {
   }
 
   protected String writeClientAdapter(ProcessingContext ctx, ControllerReader reader) throws IOException {
-    return new ClientWriter(reader, ctx).write();
+    return new ClientWriter(reader, ctx,useJsonB).write();
   }
 
 }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -27,21 +27,6 @@ public class ClientProcessor extends AbstractProcessor {
 
   protected ProcessingContext ctx;
 
-  private boolean useJsonB;
-
-  public ClientProcessor() {
-    try {
-      Class.forName("io.avaje.jsonb.Jsonb");
-      this.useJsonB = true;
-    } catch (final ClassNotFoundException e) {
-      this.useJsonB = false;
-    }
-  }
-
-  public ClientProcessor(boolean useJsonb) {
-    useJsonB = useJsonb;
-  }
-
   @Override
   public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latest();
@@ -122,7 +107,7 @@ public class ClientProcessor extends AbstractProcessor {
   }
 
   protected String writeClientAdapter(ProcessingContext ctx, ControllerReader reader) throws IOException {
-    return new ClientWriter(reader, ctx,useJsonB).write();
+    return new ClientWriter(reader, ctx).write();
   }
 
 }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -27,15 +27,16 @@ public class ClientProcessor extends AbstractProcessor {
 
   protected ProcessingContext ctx;
 
-  private boolean useJsonB;
+  private final boolean useJsonB;
 
   public ClientProcessor() {
+    var jsonBOnClassPath = false;
     try {
       Class.forName("io.avaje.jsonb.Jsonb");
-      this.useJsonB = true;
+      jsonBOnClassPath = true;
     } catch (final ClassNotFoundException e) {
-      this.useJsonB = false;
     }
+    useJsonB = jsonBOnClassPath;
   }
 
   public ClientProcessor(boolean useJsonb) {
@@ -122,7 +123,7 @@ public class ClientProcessor extends AbstractProcessor {
   }
 
   protected String writeClientAdapter(ProcessingContext ctx, ControllerReader reader) throws IOException {
-    return new ClientWriter(reader, ctx,useJsonB).write();
+    return new ClientWriter(reader, ctx, useJsonB).write();
   }
 
 }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
@@ -21,12 +21,15 @@ class ClientWriter extends BaseControllerWriter {
   private static final String SUFFIX = "HttpClient";
 
   private final List<ClientMethodWriter> methodList = new ArrayList<>();
+  private final boolean useJsonb;
 
-  ClientWriter(ControllerReader reader, ProcessingContext ctx) throws IOException {
+  ClientWriter(ControllerReader reader, ProcessingContext ctx, boolean useJsonB) throws IOException {
     super(reader, ctx, SUFFIX);
     reader.addImportType(HTTP_CLIENT_CONTEXT);
     reader.addImportType(HTTP_API_PROVIDER);
+    this.useJsonb = useJsonB;
     readMethods();
+    if (useJsonB) reader.addImportType("io.avaje.jsonb.Types");
   }
 
   @Override
@@ -38,7 +41,7 @@ class ClientWriter extends BaseControllerWriter {
   private void readMethods() {
     for (MethodReader method : reader.methods()) {
       if (method.isWebMethod()) {
-        ClientMethodWriter methodWriter = new ClientMethodWriter(method, writer, ctx);
+        final var methodWriter = new ClientMethodWriter(method, writer, ctx, useJsonb);
         methodWriter.addImportTypes(reader);
         methodList.add(methodWriter);
       }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
@@ -21,15 +21,12 @@ class ClientWriter extends BaseControllerWriter {
   private static final String SUFFIX = "HttpClient";
 
   private final List<ClientMethodWriter> methodList = new ArrayList<>();
-  private final boolean useJsonb;
 
-  ClientWriter(ControllerReader reader, ProcessingContext ctx, boolean useJsonB) throws IOException {
+  ClientWriter(ControllerReader reader, ProcessingContext ctx) throws IOException {
     super(reader, ctx, SUFFIX);
     reader.addImportType(HTTP_CLIENT_CONTEXT);
     reader.addImportType(HTTP_API_PROVIDER);
-    this.useJsonb = useJsonB;
     readMethods();
-    if (useJsonB) reader.addImportType("io.avaje.jsonb.Types");
   }
 
   @Override
@@ -41,7 +38,7 @@ class ClientWriter extends BaseControllerWriter {
   private void readMethods() {
     for (MethodReader method : reader.methods()) {
       if (method.isWebMethod()) {
-        final var methodWriter = new ClientMethodWriter(method, writer, ctx, useJsonb);
+        ClientMethodWriter methodWriter = new ClientMethodWriter(method, writer, ctx);
         methodWriter.addImportTypes(reader);
         methodList.add(methodWriter);
       }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
@@ -60,7 +60,7 @@ public class JsonBUtil {
                   "Only java.util Map, Set and List are supported JsonB Controller Collection Types");
 
             final var params =
-                type.allTypes().stream().skip(1).collect(Collectors.joining(".class, ")) + ".class";
+                type.importTypes().stream().skip(1).collect(Collectors.joining(".class, ")) + ".class";
 
             writer.append("Types.newParameterizedType(%s.class, %s))", type.mainType(), params);
           }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
@@ -1,8 +1,10 @@
 package io.avaje.http.generator.core;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class JsonBUtil {
   private JsonBUtil() {}
@@ -53,8 +55,20 @@ public class JsonBUtil {
           writer.append("%s.class).map()", type.param1());
           break;
         default:
-          throw new UnsupportedOperationException(
-              "Only java.util Map, Set and List are supported JsonB Controller Collection Types");
+          {
+            try {
+              if (Collection.class.isAssignableFrom(Class.forName(type.mainType())))
+                throw new UnsupportedOperationException(
+                    "Only java.util Map, Set and List are supported JsonB Controller Collection Types");
+            } catch (final ClassNotFoundException e) {
+              throw new UnsupportedOperationException(
+                  "Only java.util Map, Set and List are supported JsonB Controller Collection Types");
+            }
+            final var params =
+                type.allTypes().stream().skip(1).collect(Collectors.joining(".class, ")) + ".class";
+
+            writer.append("Types.newParameterizedType(%s.class, %s))", type.mainType(), params);
+          }
       }
     }
     writer.append(";").eol();

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
@@ -1,6 +1,5 @@
 package io.avaje.http.generator.core;
 
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -56,14 +55,10 @@ public class JsonBUtil {
           break;
         default:
           {
-            try {
-              if (Collection.class.isAssignableFrom(Class.forName(type.mainType())))
-                throw new UnsupportedOperationException(
-                    "Only java.util Map, Set and List are supported JsonB Controller Collection Types");
-            } catch (final ClassNotFoundException e) {
+            if (type.mainType().contains("java.util"))
               throw new UnsupportedOperationException(
                   "Only java.util Map, Set and List are supported JsonB Controller Collection Types");
-            }
+
             final var params =
                 type.allTypes().stream().skip(1).collect(Collectors.joining(".class, ")) + ".class";
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
@@ -72,13 +72,13 @@ public class JsonBUtil {
     if (type.isGeneric()) {
       final var params =
           type.importTypes().stream()
-                  .skip(1)
-                  .map(Util::shortName)
-                  .collect(Collectors.joining(".class, "))
-              + ".class";
+              .skip(1)
+              .map(Util::shortName)
+              .collect(Collectors.joining(".class, "));
 
       writer.append(
-          "Types.newParameterizedType(%s.class, %s))", Util.shortName(type.mainType()), params);
+          "Types.newParameterizedType(%s.class, %s.class))",
+          Util.shortName(type.mainType()), params);
     } else {
       writer.append("%s.class)", Util.shortName(type.mainType()));
     }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
@@ -45,15 +45,15 @@ public class JsonBUtil {
     } else {
       switch (type.mainType()) {
         case "java.util.List":
-          writeType(UType.parse(type.paramRaw()), writer);
+          writeType(type.paramRaw(), writer);
           writer.append(".list()");
           break;
         case "java.util.Set":
-          writeType(UType.parse(type.paramRaw()), writer);
+          writeType(type.paramRaw(), writer);
           writer.append(".set()");
           break;
         case "java.util.Map":
-          writeType(UType.parse(type.paramRaw()), writer);
+          writeType(type.paramRaw(), writer);
           writer.append(".map()");
           break;
         default:

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
@@ -44,7 +44,7 @@ public interface UType {
    * Return all types associated with this Utype.
    */
   default List<String> allTypes() {
-    return null;
+    return List.of();
   }
 
   /**

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
@@ -157,8 +157,8 @@ public interface UType {
 
       switch (mainType()) {
         case "java.util.Set":
-        case "java.util.Stream":
         case "java.util.List":
+        case "java.util.stream.Stream":
         case "java.util.concurrent.CompletableFuture":
         case "io.avaje.http.client.HttpCall":
           var first = rawType.indexOf("<") + 1;

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
@@ -11,6 +11,10 @@ public interface UType {
   static UType parse(TypeMirror type) {
     return Util.parseType(type);
   }
+  /** Create the UType from the given String. */
+  static UType parse(String type) {
+    return Util.parse(type);
+  }
 
   UType VOID = new VoidType();
 
@@ -49,7 +53,7 @@ public interface UType {
   }
 
   /** Return the raw generic parameter if this UType is a Collection. */
-  default String paramRaw() {
+  default UType paramRaw() {
     return null;
   }
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
@@ -40,12 +40,6 @@ public interface UType {
   default String param0() {
     return null;
   }
-  /**
-   * Return all types associated with this Utype.
-   */
-  default List<String> allTypes() {
-    return List.of();
-  }
 
   /**
    * Return the second generic parameter.
@@ -112,7 +106,7 @@ public interface UType {
 
     @Override
     public Set<String> importTypes() {
-      return Collections.singleton(rawType);
+      return rawType.startsWith("java.lang.") ? Set.of() : Collections.singleton(rawType);
     }
 
     @Override
@@ -130,10 +124,6 @@ public interface UType {
       return rawType;
     }
 
-    @Override
-    public List<String> allTypes() {
-      return List.of(rawType);
-    }
   }
 
   /**
@@ -210,11 +200,6 @@ public interface UType {
     @Override
     public String mainType() {
       return allTypes.isEmpty() ? null : allTypes.get(0);
-    }
-
-    @Override
-    public List<String> allTypes() {
-      return allTypes;
     }
 
     @Override

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
@@ -106,7 +106,9 @@ public interface UType {
 
     @Override
     public Set<String> importTypes() {
-      return rawType.startsWith("java.lang.") ? Set.of() : Collections.singleton(rawType);
+      return rawType.startsWith("java.lang.") && rawType.indexOf('.') > -1
+          ? Set.of()
+          : Collections.singleton(rawType.replace("[]", ""));
     }
 
     @Override
@@ -164,7 +166,7 @@ public interface UType {
       Set<String> set = new LinkedHashSet<>();
       for (String type : allTypes) {
         if (!type.startsWith("java.lang.") && type.indexOf('.') > -1) {
-          set.add(type);
+          set.add(type.replace("[]", ""));
         }
       }
       return set;

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
@@ -135,7 +135,7 @@ public interface UType {
    */
   class Generic implements UType {
     final String rawType;
-    final String rawParamType;
+    final UType rawParamType;
     final List<String> allTypes;
     final String shortRawType;
     final String shortName;
@@ -145,15 +145,18 @@ public interface UType {
       this.allTypes = Arrays.asList(rawType.split("[<|>|,]"));
       this.shortRawType = shortRawType(rawType, allTypes);
       this.shortName = Util.name(shortRawType);
-      this.rawParamType = extractCollectionParam();
+      final var paramTypeString = extractRawParam();
+      this.rawParamType = paramTypeString != null ? UType.parse(paramTypeString) : null;
     }
 
-    private String extractCollectionParam() {
+    private String extractRawParam() {
 
       switch (mainType()) {
         case "java.util.Set":
         case "java.util.Stream":
         case "java.util.List":
+        case "java.util.concurrent.CompletableFuture":
+        case "io.avaje.http.client.HttpCall":
           var first = rawType.indexOf("<") + 1;
           var end = rawType.lastIndexOf(">");
           return rawType.substring(first, end);
@@ -162,7 +165,7 @@ public interface UType {
           end = rawType.lastIndexOf(">");
           return rawType.substring(first, end);
         default:
-          return rawType;
+          return null;
       }
     }
 
@@ -237,7 +240,7 @@ public interface UType {
     }
 
     @Override
-    public String paramRaw() {
+    public UType paramRaw() {
       return rawParamType;
     }
   }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
@@ -40,6 +40,12 @@ public interface UType {
   default String param0() {
     return null;
   }
+  /**
+   * Return all types associated with this Utype.
+   */
+  default List<String> allTypes() {
+    return null;
+  }
 
   /**
    * Return the second generic parameter.
@@ -123,6 +129,11 @@ public interface UType {
     public String mainType() {
       return rawType;
     }
+
+    @Override
+    public List<String> allTypes() {
+      return List.of(rawType);
+    }
   }
 
   /**
@@ -199,6 +210,11 @@ public interface UType {
     @Override
     public String mainType() {
       return allTypes.isEmpty() ? null : allTypes.get(0);
+    }
+
+    @Override
+    public List<String> allTypes() {
+      return allTypes;
     }
 
     @Override

--- a/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/ControllerMethodWriter.java
+++ b/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/ControllerMethodWriter.java
@@ -103,7 +103,7 @@ class ControllerMethodWriter {
     } else if (MediaType.TEXT_PLAIN.equalsIgnoreCase(produces)) {
       writer.append("    res.writerContext().contentType(io.helidon.common.http.MediaType.TEXT_PLAIN);").eol();
     } else {
-      writer.append(    "res.writerContext().contentType(io.helidon.common.http.MediaType.parse(\"%s\"));", produces).eol();
+      writer.append("    res.writerContext().contentType(io.helidon.common.http.MediaType.parse(\"%s\"));", produces).eol();
     }
   }
 

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
@@ -2,7 +2,6 @@ package io.avaje.http.generator.javalin;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
 
 import io.avaje.http.generator.core.BaseControllerWriter;
 import io.avaje.http.generator.core.Constants;

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
@@ -1,6 +1,7 @@
 package io.avaje.http.generator.javalin;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import io.avaje.http.generator.core.BaseControllerWriter;
@@ -30,6 +31,11 @@ class ControllerWriter extends BaseControllerWriter {
       reader.addImportType("io.avaje.jsonb.JsonType");
       reader.addImportType("io.avaje.jsonb.Types");
       this.jsonTypes = JsonBUtil.jsonTypes(reader);
+      jsonTypes.values().stream()
+          .map(UType::allTypes)
+          .flatMap(List::stream)
+          .filter(s -> !s.contains("java.lang"))
+          .forEach(reader::addImportType);
     } else {
       this.jsonTypes = Map.of();
     }
@@ -85,7 +91,9 @@ class ControllerWriter extends BaseControllerWriter {
     }
 
     for (final UType type : jsonTypes.values()) {
-      writer.append("  private final JsonType<%s> %sJsonType;", PrimitiveUtil.wrap(type.full()), type.shortName()).eol();
+      final var typeString = PrimitiveUtil.wrap(type.shortType()).replace(",", ", ");
+
+      writer.append("  private final JsonType<%s> %sJsonType;", typeString, type.shortName()).eol();
     }
     writer.eol();
 

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
@@ -1,8 +1,8 @@
 package io.avaje.http.generator.javalin;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.avaje.http.generator.core.BaseControllerWriter;
 import io.avaje.http.generator.core.Constants;
@@ -32,9 +32,8 @@ class ControllerWriter extends BaseControllerWriter {
       reader.addImportType("io.avaje.jsonb.Types");
       this.jsonTypes = JsonBUtil.jsonTypes(reader);
       jsonTypes.values().stream()
-          .map(UType::allTypes)
-          .flatMap(List::stream)
-          .filter(s -> !s.contains("java.lang"))
+          .map(UType::importTypes)
+          .flatMap(Set::stream)
           .forEach(reader::addImportType);
     } else {
       this.jsonTypes = Map.of();

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
@@ -1,9 +1,16 @@
 package io.avaje.http.generator.javalin;
 
-import io.avaje.http.generator.core.*;
-
 import java.io.IOException;
 import java.util.Map;
+
+import io.avaje.http.generator.core.BaseControllerWriter;
+import io.avaje.http.generator.core.Constants;
+import io.avaje.http.generator.core.ControllerReader;
+import io.avaje.http.generator.core.JsonBUtil;
+import io.avaje.http.generator.core.MethodReader;
+import io.avaje.http.generator.core.PrimitiveUtil;
+import io.avaje.http.generator.core.ProcessingContext;
+import io.avaje.http.generator.core.UType;
 
 /**
  * Write Javalin specific Controller WebRoute handling adapter.
@@ -21,6 +28,7 @@ class ControllerWriter extends BaseControllerWriter {
     if (useJsonB) {
       reader.addImportType("io.avaje.jsonb.Jsonb");
       reader.addImportType("io.avaje.jsonb.JsonType");
+      reader.addImportType("io.avaje.jsonb.Types");
       this.jsonTypes = JsonBUtil.jsonTypes(reader);
     } else {
       this.jsonTypes = Map.of();

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
@@ -33,8 +33,7 @@ class ControllerWriter extends BaseControllerWriter {
       this.jsonTypes = JsonBUtil.jsonTypes(reader);
       jsonTypes.values().stream()
           .map(UType::importTypes)
-          .flatMap(Set::stream)
-          .forEach(reader::addImportType);
+          .forEach(reader::addImportTypes);
     } else {
       this.jsonTypes = Map.of();
     }

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinProcessor.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinProcessor.java
@@ -9,15 +9,16 @@ import java.io.IOException;
 
 public class JavalinProcessor extends BaseProcessor {
 
-  private boolean useJsonB;
+  private final boolean useJsonB;
 
   public JavalinProcessor() {
+    var jsonBOnClassPath = false;
     try {
       Class.forName("io.avaje.jsonb.Jsonb");
-      this.useJsonB = true;
+      jsonBOnClassPath = true;
     } catch (final ClassNotFoundException e) {
-      this.useJsonB = false;
     }
+    useJsonB = jsonBOnClassPath;
   }
 
   public JavalinProcessor(boolean useJsonb) {

--- a/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
+++ b/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
@@ -5,6 +5,7 @@ import io.avaje.http.generator.core.*;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Write Helidon specific web route adapter (a Helidon Service).
@@ -24,9 +25,8 @@ class ControllerWriter extends BaseControllerWriter {
       reader.addImportType("io.avaje.jsonb.Types");
       this.jsonTypes = JsonBUtil.jsonTypes(reader);
       jsonTypes.values().stream()
-          .map(UType::allTypes)
-          .flatMap(List::stream)
-          .filter(s -> !s.contains("java.lang"))
+          .map(UType::importTypes)
+          .flatMap(Set::stream)
           .forEach(reader::addImportType);
     } else {
       this.jsonTypes = Map.of();

--- a/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
+++ b/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
@@ -21,7 +21,13 @@ class ControllerWriter extends BaseControllerWriter {
     if (useJsonB) {
       reader.addImportType("io.avaje.jsonb.Jsonb");
       reader.addImportType("io.avaje.jsonb.JsonType");
+      reader.addImportType("io.avaje.jsonb.Types");
       this.jsonTypes = JsonBUtil.jsonTypes(reader);
+      jsonTypes.values().stream()
+          .map(UType::allTypes)
+          .flatMap(List::stream)
+          .filter(s -> !s.contains("java.lang"))
+          .forEach(reader::addImportType);
     } else {
       this.jsonTypes = Map.of();
     }
@@ -87,7 +93,9 @@ class ControllerWriter extends BaseControllerWriter {
       writer.append("  private final Validator validator;").eol();
     }
     for (final UType type : jsonTypes.values()) {
-      writer.append("  private final JsonType<%s> %sJsonType;", PrimitiveUtil.wrap(type.full()), type.shortName()).eol();
+      final var typeString = PrimitiveUtil.wrap(type.shortType()).replace(",", ", ");
+
+      writer.append("  private final JsonType<%s> %sJsonType;", typeString, type.shortName()).eol();
     }
     writer.eol();
 

--- a/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
+++ b/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
@@ -26,8 +26,7 @@ class ControllerWriter extends BaseControllerWriter {
       this.jsonTypes = JsonBUtil.jsonTypes(reader);
       jsonTypes.values().stream()
           .map(UType::importTypes)
-          .flatMap(Set::stream)
-          .forEach(reader::addImportType);
+          .forEach(reader::addImportTypes);
     } else {
       this.jsonTypes = Map.of();
     }

--- a/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/NimaProcessor.java
+++ b/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/NimaProcessor.java
@@ -9,15 +9,16 @@ import java.io.IOException;
 
 public class NimaProcessor extends BaseProcessor {
 
-  private boolean jsonB;
+  private final boolean jsonB;
 
   public NimaProcessor() {
+    var jsonBOnClassPath = false;
     try {
       Class.forName("io.avaje.jsonb.Jsonb");
-      this.jsonB = true;
+      jsonBOnClassPath = true;
     } catch (final ClassNotFoundException e) {
-      this.jsonB = false;
     }
+    jsonB = jsonBOnClassPath;
   }
 
   public NimaProcessor(boolean useJsonb) {

--- a/tests/test-client/pom.xml
+++ b/tests/test-client/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-client</artifactId>
-      <version>1.16</version>
+      <version>1.20</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Now can do wacky stuff like this and have it work.
```
  @Get("/get3")
  Gen<RequestModel, String, Integer> getty3() {
    return new Gen<>(new RequestModel("This Model class isn't named that well"), "stringy", 0);
  }

  @Json
  public record Gen<T, T2, T3>(T o, @Ignore T2 ignored, T3 third) {}
```
- Adds JsonB types to imports and uses the short name in the generated source
- Enhance Client Processor to generate JsonB Parameterized types
- Enhances UType to be able to retrieve the full generic type of a param for certain Generic Classes
- Enhance JsonBUtil to write Parameterized Types for JsonB controllers

Has a dependency on this PR: https://github.com/avaje/avaje-jsonb/pull/47 
Has a dependency on this PR as well: https://github.com/avaje/avaje-http-client/pull/56