### PR TITLE
[http-client] ENH: Add response as() methods that return HttpResponse wrapping bean, list and stream

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/BodyAdapter.java
+++ b/http-client/src/main/java/io/avaje/http/client/BodyAdapter.java
@@ -33,7 +33,6 @@ public interface BodyAdapter {
     throw new UnsupportedOperationException("Parameterized types not supported for this adapter");
   }
 
-
   /**
    * Return a BodyReader to read response content and convert to a list of beans.
    *

--- a/http-client/src/main/java/io/avaje/http/client/DHttpAsync.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpAsync.java
@@ -61,43 +61,72 @@ final class DHttpAsync implements HttpAsyncResponse {
 
   @Override
   public <E> CompletableFuture<E> bean(Class<E> type) {
-    return request
-      .performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray())
-      .thenApply(httpResponse -> request.asyncBean(type, httpResponse));
-  }
-
-  @Override
-  public <E> CompletableFuture<List<E>> list(Class<E> type) {
-    return request
-      .performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray())
-      .thenApply(httpResponse -> request.asyncList(type, httpResponse));
-  }
-
-  @Override
-  public <E> CompletableFuture<Stream<E>> stream(Class<E> type) {
-    return request
-      .performSendAsync(false, HttpResponse.BodyHandlers.ofLines())
-      .thenApply(httpResponse -> request.asyncStream(type, httpResponse));
+    return as(type).thenApply(HttpResponse::body);
   }
 
   @Override
   public <E> CompletableFuture<E> bean(ParameterizedType type) {
-    return request
-      .performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray())
-      .thenApply(httpResponse -> request.asyncBean(type, httpResponse));
+    final CompletableFuture<HttpResponse<E>> future = as(type);
+    return future.thenApply(HttpResponse::body);
+  }
+
+  @Override
+  public <E> CompletableFuture<HttpResponse<E>> as(Class<E> type) {
+    return asyncAsBytes().thenApply(httpResponse -> request.asyncBean(type, httpResponse));
+  }
+
+  @Override
+  public <E> CompletableFuture<HttpResponse<E>> as(ParameterizedType type) {
+    return asyncAsBytes().thenApply(httpResponse -> request.asyncBean(type, httpResponse));
+  }
+
+  @Override
+  public <E> CompletableFuture<List<E>> list(Class<E> type) {
+    return asList(type).thenApply(HttpResponse::body);
   }
 
   @Override
   public <E> CompletableFuture<List<E>> list(ParameterizedType type) {
-    return request
-      .performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray())
-      .thenApply(httpResponse -> request.asyncList(type, httpResponse));
+    final CompletableFuture<HttpResponse<List<E>>> future = asList(type);
+    return future.thenApply(HttpResponse::body);
+  }
+
+  @Override
+  public <E> CompletableFuture<HttpResponse<List<E>>> asList(Class<E> type) {
+    return asyncAsBytes().thenApply(httpResponse -> request.asyncList(type, httpResponse));
+  }
+
+  @Override
+  public <E> CompletableFuture<HttpResponse<List<E>>> asList(ParameterizedType type) {
+    return asyncAsBytes().thenApply(httpResponse -> request.asyncList(type, httpResponse));
+  }
+
+  @Override
+  public <E> CompletableFuture<Stream<E>> stream(Class<E> type) {
+    return asStream(type).thenApply(HttpResponse::body);
   }
 
   @Override
   public <E> CompletableFuture<Stream<E>> stream(ParameterizedType type) {
-    return request
-      .performSendAsync(false, HttpResponse.BodyHandlers.ofLines())
-      .thenApply(httpResponse -> request.asyncStream(type, httpResponse));
+    final CompletableFuture<HttpResponse<Stream<E>>> future = asStream(type);
+    return future.thenApply(HttpResponse::body);
+  }
+
+  @Override
+  public <E> CompletableFuture<HttpResponse<Stream<E>>> asStream(Class<E> type) {
+    return asyncAsLines().thenApply(httpResponse -> request.asyncStream(type, httpResponse));
+  }
+
+  @Override
+  public <E> CompletableFuture<HttpResponse<Stream<E>>> asStream(ParameterizedType type) {
+    return asyncAsLines().thenApply(httpResponse -> request.asyncStream(type, httpResponse));
+  }
+
+  private CompletableFuture<HttpResponse<byte[]>> asyncAsBytes() {
+    return request.performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray());
+  }
+
+  private CompletableFuture<HttpResponse<Stream<String>>> asyncAsLines() {
+    return request.performSendAsync(false, HttpResponse.BodyHandlers.ofLines());
   }
 }

--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -269,29 +269,30 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
     return bodyAdapter.beanWriter(bean.getClass()).write(bean, contentType);
   }
 
-  <T> BodyReader<T> beanReader(Class<T> cls) {
-    return bodyAdapter.beanReader(cls);
+  <T> BodyReader<T> beanReader(Class<T> type) {
+    return bodyAdapter.beanReader(type);
   }
 
-  <T> BodyReader<T> beanReader(ParameterizedType cls) {
-    return bodyAdapter.beanReader(cls);
+  <T> BodyReader<T> beanReader(ParameterizedType type) {
+    return bodyAdapter.beanReader(type);
   }
 
-  <T> T readBean(Class<T> cls, BodyContent content) {
-    return bodyAdapter.beanReader(cls).read(content);
+  <T> T readBean(Class<T> type, BodyContent content) {
+    return bodyAdapter.beanReader(type).read(content);
   }
 
-  <T> List<T> readList(Class<T> cls, BodyContent content) {
-    return bodyAdapter.listReader(cls).read(content);
+  <T> List<T> readList(Class<T> type, BodyContent content) {
+    return bodyAdapter.listReader(type).read(content);
   }
 
   @SuppressWarnings("unchecked")
-  <T> T readBean(ParameterizedType cls, BodyContent content) {
-    return (T) bodyAdapter.beanReader(cls).read(content);
+  <T> T readBean(ParameterizedType type, BodyContent content) {
+    return (T) bodyAdapter.beanReader(type).read(content);
   }
 
-  <T> List<T> readList(ParameterizedType cls, BodyContent content) {
-    return (List<T>) bodyAdapter.listReader(cls).read(content);
+  @SuppressWarnings("unchecked")
+  <T> List<T> readList(ParameterizedType type, BodyContent content) {
+    return (List<T>) bodyAdapter.listReader(type).read(content);
   }
 
   void afterResponse(DHttpClientRequest request) {

--- a/http-client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
@@ -233,6 +233,46 @@ public interface HttpAsyncResponse {
   }
 
   /**
+   * Process converting the response body to the given type.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException.
+   *
+   * <pre>{@code
+   *
+   *    clientContext.request()
+   *       ...
+   *       .POST().async()
+   *       .as(HelloDto.class)
+   *       .whenComplete((helloResponse, throwable) -> {
+   *
+   *         if (throwable != null) {
+   *           HttpException httpException = (HttpException) throwable.getCause();
+   *           int statusCode = httpException.statusCode();
+   *
+   *           // maybe convert json error response body to a bean (using Jackson/Gson)
+   *           MyErrorBean errorResponse = httpException.bean(MyErrorBean.class);
+   *           ..
+   *
+   *         } else {
+   *           int statusCode = helloResponse.statusCode();
+   *           HelloDto helloDto = helloResponse.body();
+   *           ...
+   *         }
+   *       });
+   * }</pre>
+   *
+   * @param type The bean type to convert the content to
+   * @return The CompletableFuture of the response
+   */
+  <E> CompletableFuture<HttpResponse<E>> as(Class<E> type);
+
+  /**
+   * The same as {@link #as(Class)} but using a generic type.
+   */
+  <E> CompletableFuture<HttpResponse<E>> as(ParameterizedType type);
+
+  /**
    * Process expecting a bean response body (typically from json content).
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
@@ -267,6 +307,48 @@ public interface HttpAsyncResponse {
   <E> CompletableFuture<E> bean(Class<E> type);
 
   /**
+   * Process converting the response body to a list of the given type.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException.
+   *
+   * <pre>{@code
+   *
+   *    clientContext.request()
+   *       ...
+   *       .POST().async()
+   *       .asList(HelloDto.class)
+   *       .whenComplete((helloResponse, throwable) -> {
+   *
+   *         if (throwable != null) {
+   *           // error response
+   *           HttpException httpException = (HttpException) throwable.getCause();
+   *           int statusCode = httpException.statusCode();
+   *
+   *           // maybe convert json error response body to a bean (using Jackson/Gson)
+   *           MyErrorBean errorResponse = httpException.bean(MyErrorBean.class);
+   *           ..
+   *
+   *         } else {
+   *           // success response
+   *           int statusCode = helloResponse.statusCode();
+   *           List<HelloDto> body = helloResponse.body();
+   *           ...
+   *         }
+   *       });
+   * }</pre>
+   *
+   * @param type The type to convert the content to
+   * @return The CompletableFuture of the response
+   */
+  <E> CompletableFuture<HttpResponse<List<E>>> asList(Class<E> type);
+
+  /**
+   * The same as {@link #asList(Class)} but using a generic type.
+   */
+  <E> CompletableFuture<HttpResponse<List<E>>> asList(ParameterizedType type);
+
+  /**
    * Process expecting a list of beans response body (typically from json content).
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
@@ -296,6 +378,48 @@ public interface HttpAsyncResponse {
    * @return The CompletableFuture of the response
    */
   <E> CompletableFuture<List<E>> list(Class<E> type);
+
+  /**
+   * Process converting the response body to a stream of the given type.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException.
+   *
+   * <pre>{@code
+   *
+   *    clientContext.request()
+   *       ...
+   *       .POST().async()
+   *       .asStream(HelloDto.class)
+   *       .whenComplete((helloResponse, throwable) -> {
+   *
+   *         if (throwable != null) {
+   *           // error response
+   *           HttpException httpException = (HttpException) throwable.getCause();
+   *           int statusCode = httpException.statusCode();
+   *
+   *           // maybe convert json error response body to a bean (using Jackson/Gson)
+   *           MyErrorBean errorResponse = httpException.bean(MyErrorBean.class);
+   *           ..
+   *
+   *         } else {
+   *           // success response
+   *           int statusCode = helloResponse.statusCode();
+   *           Stream<HelloDto> body = helloResponse.body();
+   *           ...
+   *         }
+   *       });
+   * }</pre>
+   *
+   * @param type The type to convert the content to
+   * @return The CompletableFuture of the response
+   */
+  <E> CompletableFuture<HttpResponse<Stream<E>>> asStream(Class<E> type);
+
+  /**
+   * The same as {@link #asStream(Class)} but using a generic type.
+   */
+  <E> CompletableFuture<HttpResponse<Stream<E>>> asStream(ParameterizedType type);
 
   /**
    * Process response as a stream of beans (x-json-stream).

--- a/http-client/src/main/java/io/avaje/http/client/HttpClientResponse.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClientResponse.java
@@ -61,10 +61,103 @@ public interface HttpClientResponse {
   <T> T read(BodyReader<T> reader);
 
   /**
+   * Return the response with the body containing a single instance of the given type.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
+   *
+   * @param type The type of the bean to convert the response content into.
+   * @param <T>  The type that the content is converted to.
+   * @return The response containing the converted body.
+   * @throws HttpException when the response has error status codes
+   */
+  <T> HttpResponse<T> as(Class<T> type);
+
+  /**
+   * Return the response with the body containing a single instance of the given parameterized type.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
+   *
+   * @param type The parameterized type of the bean to convert the response content into.
+   * @return The response containing the converted body.
+   * @throws HttpException when the response has error status codes
+   */
+  <T> HttpResponse<T> as(ParameterizedType type);
+
+  /**
+   * Return the response with the body containing a list of the given type.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
+   *
+   * @param type The type of the bean to convert the response content into.
+   * @param <T>  The type that the content is converted to.
+   * @return The response containing the converted body.
+   * @throws HttpException when the response has error status codes
+   */
+  <T> HttpResponse<List<T>> asList(Class<T> type);
+
+  /**
+   * Return the response with the body containing a list of the given parameterized type.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
+   *
+   * @param type The type of the bean to convert the response content into.
+   * @param <T>  The type that the content is converted to.
+   * @return The response containing the converted body.
+   * @throws HttpException when the response has error status codes
+   */
+  <T> HttpResponse<List<T>> asList(ParameterizedType type);
+
+  /**
+   * Return the response with the body containing a stream of beans of the given type.
+   * <p>
+   * Typically the response is expected to be {@literal application/x-json-stream}
+   * newline delimited json payload.
+   * <p>
+   * Note that for this stream request the response content is not deemed
+   * 'loggable' by avaje-http-client. This is because the entire response
+   * may not be available at the time of the callback. As such {@link RequestLogger}
+   * will not include response content when logging stream request/response
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
+   *
+   * @param type The type of the bean to convert the response content into.
+   * @param <T>  The type that the content is converted to.
+   * @return The response containing the converted body.
+   * @throws HttpException when the response has error status codes
+   */
+  <T> HttpResponse<Stream<T>> asStream(Class<T> type);
+
+  /**
+   * Return the response with the body containing a stream of beans of the given parameterized type.
+   * <p>
+   * Typically the response is expected to be {@literal application/x-json-stream}
+   * newline delimited json payload.
+   * <p>
+   * Note that for this stream request the response content is not deemed
+   * 'loggable' by avaje-http-client. This is because the entire response
+   * may not be available at the time of the callback. As such {@link RequestLogger}
+   * will not include response content when logging stream request/response
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
+   *
+   * @param type The type of the bean to convert the response content into.
+   * @param <T>  The type that the content is converted to.
+   * @return The response containing the converted body.
+   * @throws HttpException when the response has error status codes
+   */
+  <T> HttpResponse<Stream<T>> asStream(ParameterizedType type);
+
+  /**
    * Return the response as a single bean.
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
-   * the HttpResponse. This is the cause in the CompletionException.
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
    * @param type The type of the bean to convert the response content into.
    * @param <T>  The type that the content is converted to.
@@ -77,7 +170,7 @@ public interface HttpClientResponse {
    * Return the response as a list of beans.
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
-   * the HttpResponse. This is the cause in the CompletionException.
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
    * @param type The type of the bean to convert the response content into.
    * @param <T>  The type that the content is converted to.
@@ -85,7 +178,6 @@ public interface HttpClientResponse {
    * @throws HttpException when the response has error status codes
    */
   <T> List<T> list(Class<T> type);
-
 
   /**
    * Return the response as a stream of beans.
@@ -99,7 +191,7 @@ public interface HttpClientResponse {
    * will not include response content when logging stream request/response
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
-   * the HttpResponse. This is the cause in the CompletionException.
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
    * @param type The type of the bean to convert the response content into.
    * @param <T>  The type that the content is converted to.
@@ -112,7 +204,7 @@ public interface HttpClientResponse {
    * Return the response as a single bean.
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
-   * the HttpResponse. This is the cause in the CompletionException.
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
    * @param type The parameterized type of the bean to convert the response content into.
    * @return The bean the response is converted into.
@@ -124,7 +216,7 @@ public interface HttpClientResponse {
    * Return the response as a list of beans.
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
-   * the HttpResponse. This is the cause in the CompletionException.
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
    * @param type The parameterized type of the bean to convert the response content into.
    * @return The list of beans the response is converted into.
@@ -144,14 +236,13 @@ public interface HttpClientResponse {
    * will not include response content when logging stream request/response
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
-   * the HttpResponse. This is the cause in the CompletionException.
+   * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
    * @param type The parameterized type of the bean to convert the response content into.
    * @return The stream of beans from the response
    * @throws HttpException when the response has error status codes
    */
   <T> Stream<T> stream(ParameterizedType type);
-
 
   /**
    * Return the response with check for 200 range status code.

--- a/http-client/src/main/java/io/avaje/http/client/JsonbBodyAdapter.java
+++ b/http-client/src/main/java/io/avaje/http/client/JsonbBodyAdapter.java
@@ -55,14 +55,14 @@ public final class JsonbBodyAdapter implements BodyAdapter {
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> BodyReader<T> beanReader(ParameterizedType cls) {
-    return (BodyReader<T>) beanReaderCache.computeIfAbsent(cls, aClass -> new JReader<>(jsonb.type(cls)));
+  public <T> BodyReader<T> beanReader(ParameterizedType type) {
+    return (BodyReader<T>) beanReaderCache.computeIfAbsent(type, aClass -> new JReader<>(jsonb.type(type)));
   }
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> BodyReader<List<T>> listReader(ParameterizedType cls) {
-    return (BodyReader<List<T>>) listReaderCache.computeIfAbsent(cls, aClass -> new JReader<>(jsonb.type(cls).list()));
+  public <T> BodyReader<List<T>> listReader(ParameterizedType type) {
+    return (BodyReader<List<T>>) listReaderCache.computeIfAbsent(type, aClass -> new JReader<>(jsonb.type(type).list()));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
These allow access to the http status code and headers for success responses that we want as a bean, list of stream.

```java
final HttpResponse<MyDto> response = client.request()
      .path("hello/saveform")
      .formParam("name", "Bax")
      .formParam("email", "Bax@foo.com")
      .POST()
      .as(MyDto.class);           <!-- HERE !!!

// access to status code and headers
int statusCode = response.statusCode();
HttpHeaders headers = response.headers();

// with body converted to the type we desire
MyDto body = response.body();
```