### PR TITLE
[http-client] Update the client generation to use HttpClient

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/HttpApiProvider.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpApiProvider.java
@@ -15,6 +15,6 @@ public interface HttpApiProvider<T> {
   /**
    * Return the provided implementation of the API.
    */
-  T provide(HttpClientContext client);
+  T provide(HttpClient client);
 
 }

--- a/http-client/src/test/java/org/example/github/SimpleProvider.java
+++ b/http-client/src/test/java/org/example/github/SimpleProvider.java
@@ -1,7 +1,7 @@
 package org.example.github;
 
 import io.avaje.http.client.HttpApiProvider;
-import io.avaje.http.client.HttpClientContext;
+import io.avaje.http.client.HttpClient;
 import org.example.github.httpclient.Simple$HttpClient;
 
 public class SimpleProvider implements HttpApiProvider<Simple> {
@@ -12,7 +12,7 @@ public class SimpleProvider implements HttpApiProvider<Simple> {
   }
 
   @Override
-  public Simple provide(HttpClientContext client) {
+  public Simple provide(HttpClient client) {
     return new Simple$HttpClient(client);
   }
 }

--- a/http-client/src/test/java/org/example/github/httpclient/Simple$HttpClient.java
+++ b/http-client/src/test/java/org/example/github/httpclient/Simple$HttpClient.java
@@ -13,16 +13,14 @@ import java.util.List;
 
 public class Simple$HttpClient implements Simple {
 
-  private final HttpClientContext context;
+  private final HttpClient context;
   private final BodyReader<Repo> readRepo;
   private final BodyWriter writeRepo;
-//  private final BodyConverter<List<Repo>, String> toListOfRepo;
 
-  public Simple$HttpClient(HttpClientContext context) {
+  public Simple$HttpClient(HttpClient context) {
     this.context = context;
-    this.readRepo = context.converters().beanReader(Repo.class);
-    this.writeRepo = context.converters().beanWriter(Repo.class);
-//    this.toListOfRepo = context.converters().toListOf(Repo.class);
+    this.readRepo = context.bodyAdapter().beanReader(Repo.class);
+    this.writeRepo = context.bodyAdapter().beanWriter(Repo.class);
   }
 
   @Get("users/{user}/repos")
@@ -75,7 +73,7 @@ public class Simple$HttpClient implements Simple {
     }
 
     @Override
-    public Simple provide(HttpClientContext client) {
+    public Simple provide(HttpClient client) {
       return new Simple$HttpClient(client);
     }
   }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -76,7 +76,7 @@ class ClientMethodWriter {
     if (!method.isVoid()) {
       writer.append("return ");
     }
-    writer.append("clientContext.request()").eol();
+    writer.append("client.request()").eol();
 
     PathSegments pathSegments = method.pathSegments();
     Set<PathSegments.Segment> segments = pathSegments.segments();

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
@@ -14,7 +14,7 @@ import java.util.List;
  */
 class ClientWriter extends BaseControllerWriter {
 
-  private static final String HTTP_CLIENT_CONTEXT = "io.avaje.http.client.HttpClientContext";
+  private static final String HTTP_CLIENT = "io.avaje.http.client.HttpClient";
   private static final String HTTP_API_PROVIDER = "io.avaje.http.client.HttpApiProvider";
 
   private static final String AT_GENERATED = "@Generated(\"avaje-http-client-generator\")";
@@ -25,7 +25,7 @@ class ClientWriter extends BaseControllerWriter {
 
   ClientWriter(ControllerReader reader, ProcessingContext ctx, boolean useJsonB) throws IOException {
     super(reader, ctx, SUFFIX);
-    reader.addImportType(HTTP_CLIENT_CONTEXT);
+    reader.addImportType(HTTP_CLIENT);
     reader.addImportType(HTTP_API_PROVIDER);
     this.useJsonb = useJsonB;
     readMethods();
@@ -65,7 +65,7 @@ class ClientWriter extends BaseControllerWriter {
     writer.append("      return %s.class;", shortName).eol();
     writer.append("    }").eol();
     writer.append("    @Override").eol();
-    writer.append("    public %s provide(HttpClientContext client) {", shortName).eol();
+    writer.append("    public %s provide(HttpClient client) {", shortName).eol();
     writer.append("      return new %s%s(client);", shortName, SUFFIX).eol();
     writer.append("    }").eol();
     writer.append("  }").eol();
@@ -81,10 +81,10 @@ class ClientWriter extends BaseControllerWriter {
     writer.append(AT_GENERATED).eol();
     writer.append("public class %s%s implements %s {", shortName, SUFFIX, shortName).eol().eol();
 
-    writer.append("  private final HttpClientContext clientContext;").eol().eol();
+    writer.append("  private final HttpClient client;").eol().eol();
 
-    writer.append("  public %s%s(HttpClientContext ctx) {", shortName, SUFFIX).eol();
-    writer.append("    this.clientContext = ctx;").eol();
+    writer.append("  public %s%s(HttpClient client) {", shortName, SUFFIX).eol();
+    writer.append("    this.client = client;").eol();
     writer.append("  }").eol().eol();
   }
 

--- a/tests/test-client-generation/src/test/java/org/example/SimpleTest.java
+++ b/tests/test-client-generation/src/test/java/org/example/SimpleTest.java
@@ -3,9 +3,9 @@ package org.example;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.avaje.http.client.HttpApiProvider;
+import io.avaje.http.client.HttpClient;
 import io.avaje.http.client.HttpClientContext;
 import io.avaje.http.client.JacksonBodyAdapter;
-
 import org.example.httpclient.GitHubUsersHttpClient;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -45,7 +45,7 @@ public class SimpleTest {
     }
 
     @Override
-    public GitHubUsers provide(HttpClientContext client) {
+    public GitHubUsers provide(HttpClient client) {
       return new GitHubUsersHttpClient(client);
     }
   }

--- a/tests/test-client/src/main/java/example/github/SimpleHttpClient.java
+++ b/tests/test-client/src/main/java/example/github/SimpleHttpClient.java
@@ -1,9 +1,7 @@
 package example.github;
 
-//import io.avaje.http.api.Get;
-
 import io.avaje.http.client.HttpApiProvider;
-import io.avaje.http.client.HttpClientContext;
+import io.avaje.http.client.HttpClient;
 import io.avaje.http.client.HttpException;
 
 import java.util.List;
@@ -19,15 +17,15 @@ public class SimpleHttpClient implements HttpApiProvider<Simple> {
   }
 
   @Override
-  public Simple provide(HttpClientContext client) {
+  public Simple provide(HttpClient client) {
     return new SimpleClient(client);
   }
 
   private static class SimpleClient implements Simple {
 
-    private final HttpClientContext context;
+    private final HttpClient context;
 
-    SimpleClient(HttpClientContext context) {
+    SimpleClient(HttpClient context) {
       this.context = context;
     }
 


### PR DESCRIPTION
This also changes the HttpApiProvider interface to use HttpClient so this generated code really wants the same version of the HttpClient which I think is reasonable.