### PR TITLE
Simplify useJavax determination in ProcessingContext

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -58,10 +58,8 @@ public class ProcessingContext {
     final var override = env.getOptions().get("useJavax");
     if (override != null || (javax && jakarta)) {
       this.useJavax = Boolean.parseBoolean(override);
-    } else if (javax && !jakarta) {
-      useJavax = javax;
     } else {
-      useJavax = false;
+      this.useJavax = javax;
     }
   }
 


### PR DESCRIPTION
IntelliJ warned that for `javax && !jakarta` the !jakarta part was always true. That leads to this simplification.