### PR TITLE
[http-client] Add code generation for the as() methods returning HttpResponse<E> etc

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/DHttpCall.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpCall.java
@@ -56,6 +56,36 @@ final class DHttpCall implements HttpCallResponse {
   }
 
   @Override
+  public <E> HttpCall<HttpResponse<E>> as(Class<E> type) {
+    return new CallAs<>(type);
+  }
+
+  @Override
+  public <E> HttpCall<HttpResponse<E>> as(ParameterizedType type) {
+    return new CallAs<>(type);
+  }
+
+  @Override
+  public <E> HttpCall<HttpResponse<List<E>>> asList(Class<E> type) {
+    return new CallAsList<>(type);
+  }
+
+  @Override
+  public <E> HttpCall<HttpResponse<List<E>>> asList(ParameterizedType type) {
+    return new CallAsList<>(type);
+  }
+
+  @Override
+  public <E> HttpCall<HttpResponse<Stream<E>>> asStream(Class<E> type) {
+    return new CallAsStream<>(type);
+  }
+
+  @Override
+  public <E> HttpCall<HttpResponse<Stream<E>>> asStream(ParameterizedType type) {
+    return new CallAsStream<>(type);
+  }
+
+  @Override
   public <E> HttpCall<List<E>> list(Class<E> type) {
     return new CallList<>(type);
   }
@@ -85,6 +115,7 @@ final class DHttpCall implements HttpCallResponse {
     public HttpResponse<Void> execute() {
       return request.asVoid();
     }
+
     @Override
     public CompletableFuture<HttpResponse<Void>> async() {
       return request.async().asVoid();
@@ -96,6 +127,7 @@ final class DHttpCall implements HttpCallResponse {
     public HttpResponse<Void> execute() {
       return request.asDiscarding();
     }
+
     @Override
     public CompletableFuture<HttpResponse<Void>> async() {
       return request.async().asDiscarding();
@@ -107,6 +139,7 @@ final class DHttpCall implements HttpCallResponse {
     public HttpResponse<String> execute() {
       return request.asString();
     }
+
     @Override
     public CompletableFuture<HttpResponse<String>> async() {
       return request.async().asString();
@@ -118,6 +151,7 @@ final class DHttpCall implements HttpCallResponse {
     public HttpResponse<byte[]> execute() {
       return request.asByteArray();
     }
+
     @Override
     public CompletableFuture<HttpResponse<byte[]>> async() {
       return request.async().asByteArray();
@@ -129,6 +163,7 @@ final class DHttpCall implements HttpCallResponse {
     public HttpResponse<Stream<String>> execute() {
       return request.asLines();
     }
+
     @Override
     public CompletableFuture<HttpResponse<Stream<String>>> async() {
       return request.async().asLines();
@@ -140,9 +175,94 @@ final class DHttpCall implements HttpCallResponse {
     public HttpResponse<InputStream> execute() {
       return request.asInputStream();
     }
+
     @Override
     public CompletableFuture<HttpResponse<InputStream>> async() {
       return request.async().asInputStream();
+    }
+  }
+
+  private class CallAs<E> implements HttpCall<HttpResponse<E>> {
+    private final Class<E> type;
+    private final ParameterizedType genericType;
+    private final boolean isGeneric;
+
+    CallAs(Class<E> type) {
+      this.isGeneric = false;
+      this.type = type;
+      this.genericType = null;
+    }
+
+    CallAs(ParameterizedType type) {
+      this.isGeneric = true;
+      this.type = null;
+      this.genericType = type;
+    }
+
+    @Override
+    public HttpResponse<E> execute() {
+      return isGeneric ? request.as(genericType) : request.as(type);
+    }
+
+    @Override
+    public CompletableFuture<HttpResponse<E>> async() {
+      return isGeneric ? request.async().as(genericType) : request.async().as(type);
+    }
+  }
+
+  private class CallAsList<E> implements HttpCall<HttpResponse<List<E>>> {
+    private final Class<E> type;
+    private final ParameterizedType genericType;
+    private final boolean isGeneric;
+
+    CallAsList(Class<E> type) {
+      this.isGeneric = false;
+      this.type = type;
+      this.genericType = null;
+    }
+
+    CallAsList(ParameterizedType type) {
+      this.isGeneric = true;
+      this.type = null;
+      this.genericType = type;
+    }
+
+    @Override
+    public HttpResponse<List<E>> execute() {
+      return isGeneric ? request.asList(genericType) : request.asList(type);
+    }
+
+    @Override
+    public CompletableFuture<HttpResponse<List<E>>> async() {
+      return isGeneric ? request.async().asList(genericType) : request.async().asList(type);
+    }
+  }
+
+  private class CallAsStream<E> implements HttpCall<HttpResponse<Stream<E>>> {
+    private final Class<E> type;
+    private final ParameterizedType genericType;
+    private final boolean isGeneric;
+
+    CallAsStream(Class<E> type) {
+      this.isGeneric = false;
+      this.type = type;
+      this.genericType = null;
+    }
+
+    CallAsStream(ParameterizedType type) {
+      this.isGeneric = true;
+      this.type = null;
+      this.genericType = type;
+    }
+
+    @Override
+    public HttpResponse<Stream<E>> execute() {
+      return isGeneric ? request.asStream(genericType) : request.asStream(type);
+    }
+
+    @Override
+    public CompletableFuture<HttpResponse<Stream<E>>> async() {
+      return isGeneric ? request.async().asStream(genericType) : request.async().asStream(type);
     }
   }
 
@@ -232,13 +352,16 @@ final class DHttpCall implements HttpCallResponse {
 
   private class CallHandler<E> implements HttpCall<HttpResponse<E>> {
     private final HttpResponse.BodyHandler<E> handler;
+
     CallHandler(HttpResponse.BodyHandler<E> handler) {
       this.handler = handler;
     }
+
     @Override
     public HttpResponse<E> execute() {
       return request.handler(handler);
     }
+
     @Override
     public CompletableFuture<HttpResponse<E>> async() {
       return request.async().handler(handler);

--- a/http-client/src/main/java/io/avaje/http/client/HttpCallResponse.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpCallResponse.java
@@ -134,8 +134,54 @@ public interface HttpCallResponse {
    *
    * <pre>{@code
    *
+   *  HttpCall<HttpResponse<HelloDto>> call =
+   *    client.request()
+   *       ...
+   *       .POST()
+   *       .call().as(HelloDto.class);
+   *
+   * }</pre>
+   *
+   * @param type The bean type to convert the content to
+   * @return The HttpCall to allow sync or async execution
+   */
+  <E> HttpCall<HttpResponse<E>> as(Class<E> type);
+
+  /**
+   * Same as {@link #as(Class)} but takes a generic parameterized type.
+   */
+  <E> HttpCall<HttpResponse<E>> as(ParameterizedType type);
+
+  /**
+   * Same as {@link #as(Class)} but returns {@code HttpResponse<List<E>>}.
+   */
+  <E> HttpCall<HttpResponse<List<E>>> asList(Class<E> type);
+
+  /**
+   * Same as {@link #as(Class)} but returns {@code HttpResponse<List<E>>}.
+   */
+  <E> HttpCall<HttpResponse<List<E>>> asList(ParameterizedType type);
+
+  /**
+   * Same as {@link #as(Class)} but returns {@code HttpResponse<Stream<E>>}.
+   */
+  <E> HttpCall<HttpResponse<Stream<E>>> asStream(Class<E> type);
+
+  /**
+   * Same as {@link #as(Class)} but returns {@code HttpResponse<Stream<E>>}.
+   */
+  <E> HttpCall<HttpResponse<Stream<E>>> asStream(ParameterizedType type);
+
+  /**
+   * A bean response to execute async or sync.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException.
+   *
+   * <pre>{@code
+   *
    *  HttpCall<HelloDto> call =
-   *    clientContext.request()
+   *    client.request()
    *       ...
    *       .POST()
    *       .call().bean(HelloDto.class);
@@ -156,7 +202,7 @@ public interface HttpCallResponse {
    * <pre>{@code
    *
    *  HttpCall<List<HelloDto>> call =
-   *    clientContext.request()
+   *    client.request()
    *       ...
    *       .GET()
    *       .call().list(HelloDto.class);
@@ -176,7 +222,7 @@ public interface HttpCallResponse {
    * <pre>{@code
    *
    *  HttpCall<Stream<HelloDto>> call =
-   *    clientContext.request()
+   *    client.request()
    *       ...
    *       .GET()
    *       .call().stream(HelloDto.class);

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -137,7 +137,20 @@ class ClientMethodWriter {
       writer.append(".stream(");
       writeGeneric(param1);
     } else if (isHttpResponse(mainType)) {
-      writeWithHandler();
+      if (bodyHandlerParam == null) {
+        UType paramType = type.paramRaw();
+        if (paramType.mainType().equals("java.util.List")) {
+          writer.append(".asList(");
+          writeGeneric(paramType.paramRaw());
+        } else if (paramType.mainType().equals("java.util.stream.Stream")) {
+          writer.append(".asStream(");
+          writeGeneric(paramType.paramRaw());
+        } else {
+          writer.append(".as(");
+          writeGeneric(paramType);
+        }
+      } else {
+        writer.append(".handler(%s);", bodyHandlerParam.name()).eol();      }
     } else {
       writer.append(".bean(");
       writeGeneric(type);
@@ -157,14 +170,6 @@ class ClientMethodWriter {
       writer.append("%s.class", Util.shortName(type.mainType()));
     }
     writer.append(");").eol();
-  }
-
-  private void writeWithHandler() {
-    if (bodyHandlerParam != null) {
-      writer.append(".handler(%s);", bodyHandlerParam.name()).eol();
-    } else {
-      writer.append(".handler(responseHandler);").eol(); // Better to barf here?
-    }
   }
 
   private void writeQueryParams(PathSegments pathSegments) {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/UType.java
@@ -165,6 +165,7 @@ public interface UType {
         case "java.util.Set":
         case "java.util.List":
         case "java.util.stream.Stream":
+        case "java.net.http.HttpResponse":
         case "java.util.concurrent.CompletableFuture":
         case "io.avaje.http.client.HttpCall":
           var first = rawType.indexOf("<") + 1;

--- a/tests/test-client-generation/src/main/java/org/example/WithAsResponseApi.java
+++ b/tests/test-client-generation/src/main/java/org/example/WithAsResponseApi.java
@@ -1,0 +1,35 @@
+package org.example;
+
+import io.avaje.http.api.Client;
+import io.avaje.http.api.Get;
+import io.avaje.http.client.HttpCall;
+
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@Client
+public interface WithAsResponseApi {
+
+  @Get("/{id}")
+  Repo get(UUID id);
+
+  @Get("/as/{id}")
+  HttpResponse<Repo> getAs(UUID id);
+
+  @Get("/as-list/{id}")
+  HttpResponse<List<Repo>> getAsList(UUID id);
+
+  @Get("/as-stream/{id}")
+  HttpResponse<Stream<Repo>> getAsStream(UUID id);
+
+  @Get("/call-as/{id}")
+  HttpCall<HttpResponse<Repo>> getCallAs(UUID id);
+
+  @Get("/call-as-list/{id}")
+  HttpCall<HttpResponse<List<Repo>>> getCallAsList(UUID id);
+
+  @Get("/call-as-stream/{id}")
+  HttpCall<HttpResponse<Stream<Repo>>> getCallAsStream(UUID id);
+}


### PR DESCRIPTION
Supports code generation for client API methods like the following:

```java
@Client
public interface MyApi {

  @Get("/as/{id}")
  HttpResponse<Repo> getAs(UUID id);

  @Get("/as-list/{id}")
  HttpResponse<List<Repo>> getAsList(UUID id);

  @Get("/as-stream/{id}")
  HttpResponse<Stream<Repo>> getAsStream(UUID id);

  @Get("/call-as/{id}")
  HttpCall<HttpResponse<Repo>> getCallAs(UUID id);

  @Get("/call-as-list/{id}")
  HttpCall<HttpResponse<List<Repo>>> getCallAsList(UUID id);

  @Get("/call-as-stream/{id}")
  HttpCall<HttpResponse<Stream<Repo>>> getCallAsStream(UUID id);
}
```