### PR TITLE
Inherit interface roles and class openAPIResponse

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/OpenAPIResponse.java
+++ b/http-api/src/main/java/io/avaje/http/api/OpenAPIResponse.java
@@ -1,6 +1,7 @@
 package io.avaje.http.api;
 
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Repeatable;
@@ -21,8 +22,8 @@ import java.lang.annotation.Target;
  *
  * }</pre>
  */
-@Target(value = METHOD)
-@Retention(value = RUNTIME)
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
 @Repeatable(OpenAPIResponses.class)
 public @interface OpenAPIResponse {
 

--- a/http-api/src/main/java/io/avaje/http/api/OpenAPIResponse.java
+++ b/http-api/src/main/java/io/avaje/http/api/OpenAPIResponse.java
@@ -12,7 +12,9 @@ import java.lang.annotation.Target;
  * Specify endpoint response status code/description/type.
  *
  * <p>When not specified the default 2xx openAPI generation is based on the javadoc of the method.
- * <p> Will not override the default 2xx generated openapi unless status code is 2xx
+ *
+ * <p>Will not override the default 2xx generated openapi unless status code is 2xx
+ *
  * <pre>{@code
  * @Post("/post")
  * @OpenAPIReturns(responseCode = "200", description = "from annotaion")
@@ -20,6 +22,18 @@ import java.lang.annotation.Target;
  * @OpenAPIReturns(responseCode = "500", description = "Some other Error", type=ErrorResponse.class)
  * ResponseModel endpoint() {}
  *
+ * }</pre>
+ *
+ * <p>Can also be placed on a class to add to every method in the controller.
+ *
+ * <pre>{@code
+ * @OpenAPIResponse(
+ * responseCode = "403",
+ * description = "Insufficient rights to this resource."
+ * )
+ * public class MyController {
+ * ...
+ * }
  * }</pre>
  */
 @Target({TYPE, METHOD})

--- a/http-api/src/main/java/io/avaje/http/api/OpenAPIResponses.java
+++ b/http-api/src/main/java/io/avaje/http/api/OpenAPIResponses.java
@@ -1,6 +1,7 @@
 package io.avaje.http.api;
 
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
@@ -11,8 +12,8 @@ import java.lang.annotation.Target;
  *
  * @see OpenAPIResponse
  */
-@Target(value = METHOD)
-@Retention(value = RUNTIME)
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
 public @interface OpenAPIResponses {
   OpenAPIResponse[] value();
 }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerReader.java
@@ -4,6 +4,7 @@ import static java.util.function.Predicate.not;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -21,6 +22,8 @@ import javax.lang.model.util.ElementFilter;
 import javax.validation.Valid;
 
 import io.avaje.http.api.Controller;
+import io.avaje.http.api.OpenAPIResponse;
+import io.avaje.http.api.OpenAPIResponses;
 import io.avaje.http.api.Path;
 import io.avaje.http.api.Produces;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -38,6 +41,7 @@ public class ControllerReader {
   private final List<MethodReader> methods = new ArrayList<>();
   private final Set<String> staticImportTypes = new TreeSet<>();
   private final Set<String> importTypes = new TreeSet<>();
+  private final List<OpenAPIResponse> apiResponses;
 
   /**
    * The produces media type for the controller. Null implies JSON.
@@ -57,12 +61,46 @@ public class ControllerReader {
     this.ctx = ctx;
     this.interfaces = initInterfaces();
     this.interfaceMethods = initInterfaceMethods();
-    this.roles = Util.findRoles(beanType);
+    this.roles = buildRoles();
     if (ctx.isOpenApiAvailable()) {
       docHidden = initDocHidden();
     }
     this.hasValid = initHasValid();
     this.produces = initProduces();
+    this.apiResponses = buildApiResponses();
+  }
+
+  private List<OpenAPIResponse> buildApiResponses() {
+    final var responses = new ArrayList<OpenAPIResponse>();
+
+    Optional.ofNullable(beanType.getAnnotation(OpenAPIResponses.class)).stream()
+        .map(OpenAPIResponses::value)
+        .flatMap(Arrays::stream)
+        .forEach(responses::add);
+
+    Arrays.stream(beanType.getAnnotationsByType(OpenAPIResponse.class)).forEach(responses::add);
+
+    for (final Element anInterface : interfaces) {
+
+      Optional.ofNullable(anInterface.getAnnotation(OpenAPIResponses.class)).stream()
+          .map(OpenAPIResponses::value)
+          .flatMap(Arrays::stream)
+          .forEach(responses::add);
+
+      Arrays.stream(anInterface.getAnnotationsByType(OpenAPIResponse.class))
+          .forEach(responses::add);
+    }
+
+    return responses;
+  }
+
+  private ArrayList<String> buildRoles() {
+    final var roleList = new ArrayList<>(Util.findRoles(beanType));
+
+    for (final Element anInterface : interfaces) {
+      roleList.addAll(Util.findRoles(anInterface));
+    }
+    return roleList;
   }
 
   protected void addImports(boolean withSingleton) {
@@ -265,6 +303,10 @@ public class ControllerReader {
 
   public List<MethodReader> methods() {
     return methods;
+  }
+
+  public List<OpenAPIResponse> openApiResponses() {
+    return apiResponses;
   }
 
   public String path() {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
@@ -170,8 +170,12 @@ public class MethodReader {
                 .map(OpenAPIResponses::value)
                 .flatMap(Arrays::stream),
               Arrays.stream(method.getAnnotationsByType(OpenAPIResponse.class))));
-
-    return Stream.concat(methodResponses, superMethodResponses).collect(Collectors.toList());
+    
+    var responses =
+        Stream.concat(methodResponses, superMethodResponses).collect(Collectors.toList());
+    
+    responses.addAll(bean.openApiResponses());
+    return responses;
   }
 
   public <A extends Annotation> A findAnnotation(Class<A> type) {

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/HealthController.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/HealthController.java
@@ -1,5 +1,8 @@
 package org.example.myapp.web.test;
 
+import org.example.myapp.web.AppRoles;
+import org.example.myapp.web.Roles;
+
 import io.avaje.http.api.Get;
 import io.avaje.http.api.MediaType;
 import io.avaje.http.api.OpenAPIResponse;
@@ -10,11 +13,13 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Path("javalin")
+@Roles(AppRoles.ANYONE)
 @OpenAPIDefinition(
     info =
         @Info(
             title = "Example service showing off the Path extension method of controller",
             description = ""))
+@OpenAPIResponse(responseCode = "403", description = "Not Authorized")
 public interface HealthController {
   /**
    * Standard Get

--- a/tests/test-javalin-jsonb/src/test/resources/expectedInheritedOpenApi.json
+++ b/tests/test-javalin-jsonb/src/test/resources/expectedInheritedOpenApi.json
@@ -29,6 +29,9 @@
 							}
 						}
 					},
+					"403" : {
+						"description" : "Not Authorized"
+					},
 					"200" : {
 						"description" : "a health check",
 						"content" : {


### PR DESCRIPTION
- change `@OpenAPIResponse` to work on classes
- if defined on a class all the routes in the class will  have the definition added to the openapi
- make interface-level roles inheritable.

Now instead of doing:
```
public class MyController {

  @OpenAPIResponse(
    responseCode = "403",
    description = "Insufficient rights to this resource."
  )
  @Get("/some-authenticated-route")
  public Object getObject(...) { ... }

  @OpenAPIResponse(
    responseCode = "403",
    description = "Insufficient rights to this resource."
  )
  @Get("/another-authenticated-route")
  public Object getObject2(...) { ... }
}
```

We can do this:
```
  @OpenAPIResponse(
    responseCode = "403",
    description = "Insufficient rights to this resource."
  )
public class MyController {

  @Get("/some-authenticated-route")
  public Object getObject(...) { ... }

  @Get("/another-authenticated-route")
  public Object getObject2(...) { ... }
}
```