### PR TITLE
ISSUE-158: Fix CompletableFuture jsonb generation

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
@@ -33,7 +33,13 @@ public class JsonBUtil {
             methodReader -> {
               addJsonBodyType(methodReader, addToMap);
               if (!methodReader.isVoid()) {
-                addToMap.accept(UType.parse(methodReader.returnType()));
+                UType uType = UType.parse(methodReader.returnType());
+
+                if (uType.mainType().equals("java.util.concurrent.CompletableFuture")) {
+                  uType = uType.paramRaw();
+                }
+
+                addToMap.accept(uType);
               }
             });
 
@@ -50,12 +56,6 @@ public class JsonBUtil {
   }
 
   public static void writeJsonbType(UType type, Append writer) {
-    // Support for CompletableFuture's.
-    if (type.mainType().equals("java.util.concurrent.CompletableFuture")) {
-      writeJsonbType(type.paramRaw(), writer);
-      return;
-    }
-
     writer.append("    this.%sJsonType = jsonB.type(", type.shortName());
     if (!type.isGeneric()) {
       writer.append("%s.class)", Util.shortName(PrimitiveUtil.wrap(type.full())));

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerWriter.java
@@ -88,17 +88,6 @@ class ControllerWriter extends BaseControllerWriter {
     }
 
     for (UType type : jsonTypes.values()) {
-      // Support for CompletableFuture's.
-      if (type.mainType().equals("java.util.concurrent.CompletableFuture")) {
-        type = type.paramRaw();
-
-        if (this.jsonTypes.containsKey(type.full())) {
-          // Already written before -- we can skip.
-          continue;
-        }
-      }
-
-      // Everything else
       final var typeString = PrimitiveUtil.wrap(type.shortType()).replace(",", ", ");
       writer.append("  private final JsonType<%s> %sJsonType;", typeString, type.shortName()).eol();
     }
@@ -117,13 +106,7 @@ class ControllerWriter extends BaseControllerWriter {
       writer.append("    this.validator = validator;").eol();
     }
     if (useJsonB) {
-      for (final UType type : jsonTypes.values()) {
-        // Skip trying to assign a global variable value for any UType that is a Completable Future. Because the paramRaw() should
-        // already be in this jsonTypes map anyway and write the assignment all by itself.
-        if (type.mainType().equals("java.util.concurrent.CompletableFuture")) {
-          continue;
-        }
-
+      for (UType type : jsonTypes.values()) {
         JsonBUtil.writeJsonbType(type, writer);
       }
     }

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController.java
@@ -3,8 +3,10 @@ package org.example.myapp.web.test;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.example.myapp.web.AppRoles;
+import org.example.myapp.web.HelloDto;
 import org.example.myapp.web.Roles;
 
 import io.avaje.http.api.Controller;
@@ -122,4 +124,10 @@ public class TestController {
 
     System.out.println("Ever have that feeling where you're not sure if you're awake or dreaming?");
   }
+
+  @Get("/async")
+  CompletableFuture<HelloDto> getAllAsync() {
+    return CompletableFuture.supplyAsync(() -> new HelloDto(12, "Jim", "asd"));
+  }
+
 }


### PR DESCRIPTION
Similar to https://github.com/avaje/avaje-http/pull/159 but with a slightly different approach. I decided after some more time with the code that it'd be best to update `jsonTypes` when it's being generated rather than having the dodgy if statements when we iterate through the `jsonTypes.values()`.

I do like the `UType.isCFuture()` definition though as it creates a better standardisation. 
Thoughts?

Fixes #158 