### PR TITLE
Support Enum Query/Form Parameters

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ElementReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ElementReader.java
@@ -2,7 +2,10 @@ package io.avaje.http.generator.core;
 
 import static io.avaje.http.generator.core.ParamType.RESPONSE_HANDLER;
 
+import java.util.Optional;
+
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 
 import io.avaje.http.generator.core.openapi.MethodDocBuilder;
@@ -42,7 +45,19 @@ public class ElementReader {
     this.rawType = rawType;
     this.shortType = Util.shortName(rawType);
     this.contextType = ctx.platform().isContextType(rawType);
-    this.typeHandler = TypeMap.get(rawType);
+
+    if (type != null
+        && (defaultType == ParamType.FORMPARAM || defaultType == ParamType.QUERYPARAM)
+        && Optional.ofNullable(ctx.typeElement(type.mainType()))
+            .map(TypeElement::getKind)
+            .filter(ElementKind.ENUM::equals)
+            .isPresent()) {
+
+      this.typeHandler = TypeMap.enumParamHandler(type);
+    } else {
+
+      this.typeHandler = TypeMap.get(rawType);
+    }
     this.formMarker = formMarker;
     this.varName = element.getSimpleName().toString();
     this.snakeName = Util.snakeCase(varName);

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/TypeMap.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/TypeMap.java
@@ -43,6 +43,20 @@ class TypeMap {
     return types.get(type);
   }
 
+  static TypeHandler enumParamHandler(UType type) {
+    return new ObjectHandler(type.mainType(), type.shortName()) {
+      @Override
+      public String toMethod() {
+        return type.shortType() + ".valueOf(";
+      }
+
+      @Override
+      public String asMethod() {
+        return "java.util. Objects.toString(";
+      }
+    };
+  }
+
   static class StringHandler extends JavaLangType {
     StringHandler() {
       super("String");

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/TypeMap.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/TypeMap.java
@@ -44,17 +44,7 @@ class TypeMap {
   }
 
   static TypeHandler enumParamHandler(UType type) {
-    return new ObjectHandler(type.mainType(), type.shortName()) {
-      @Override
-      public String toMethod() {
-        return type.shortType() + ".valueOf(";
-      }
-
-      @Override
-      public String asMethod() {
-        return "java.util. Objects.toString(";
-      }
-    };
+    return new EnumHandler(type);
   }
 
   static class StringHandler extends JavaLangType {
@@ -183,7 +173,7 @@ class TypeMap {
     }
   }
 
-  static abstract class JavaLangType implements TypeHandler {
+  abstract static class JavaLangType implements TypeHandler {
 
     final String shortName;
 
@@ -207,7 +197,7 @@ class TypeMap {
     }
   }
 
-  static abstract class Primitive implements TypeHandler {
+  abstract static class Primitive implements TypeHandler {
 
     private final String type;
 
@@ -291,8 +281,27 @@ class TypeMap {
     }
   }
 
+  static class EnumHandler extends ObjectHandler {
+    private final UType type;
 
-  static abstract class ObjectHandler implements TypeHandler {
+    EnumHandler(UType type) {
+
+      super(type.mainType(), type.shortName());
+      this.type = type;
+    }
+
+    @Override
+    public String toMethod() {
+      return type.shortType() + ".valueOf(";
+    }
+
+    @Override
+    public String asMethod() {
+      return "java.util.Objects.toString(";
+    }
+  }
+
+  abstract static class ObjectHandler implements TypeHandler {
 
     private final String importType;
     private final String shortName;

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/ServerType.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/ServerType.java
@@ -1,0 +1,7 @@
+package org.example.myapp.web.test;
+
+public enum ServerType {
+  PROXY,
+  HIDE_N_SEEK,
+  FFA
+}

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController.java
@@ -129,5 +129,4 @@ public class TestController {
   CompletableFuture<HelloDto> getAllAsync() {
     return CompletableFuture.supplyAsync(() -> new HelloDto(12, "Jim", "asd"));
   }
-
 }

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController2.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController2.java
@@ -1,0 +1,38 @@
+package org.example.myapp.web.test;
+
+import org.example.myapp.web.HelloDto;
+
+import io.avaje.http.api.Controller;
+import io.avaje.http.api.Default;
+import io.avaje.http.api.Form;
+import io.avaje.http.api.FormParam;
+import io.avaje.http.api.Get;
+import io.avaje.http.api.Path;
+import io.avaje.http.api.Post;
+import io.avaje.http.api.QueryParam;
+
+@Path("test/")
+@Controller
+public class TestController2 {
+
+  @Form
+  @Get("/enumForm")
+  String enumForm(String s, ServerType type) {
+    return type.name();
+  }
+
+  @Get("/enumFormParam")
+  String enumFormParam(@FormParam String s, @FormParam ServerType type) {
+    return type.name();
+  }
+
+  @Get("/enumQuery")
+  String enumQuery(@QueryParam @Default("FFA") ServerType type) {
+    return type.name();
+  }
+
+  @Post("/enumQueryImplied")
+  String enumQueryImplied(HelloDto s, ServerType type) {
+    return type.name();
+  }
+}


### PR DESCRIPTION
Now can use simple Enums as Query Params

- adds an Enum TypeHandler for Certain Param Types

This PR is further expanded by #167 