### PR TITLE
HttpClientRequest Now Supports Multi-Value Headers/Query Parameters

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.net.http.HttpResponse.BodyHandlers.discarding;
@@ -124,7 +125,25 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
   }
 
   @Override
+  public HttpClientRequest header(String name, Collection<String> value) {
+    if (headers == null) {
+      headers = new LinkedHashMap<>();
+    }
+    headers.computeIfAbsent(name, s -> new ArrayList<>()).addAll(value);
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
   public HttpClientRequest header(String name, Object value) {
+
+    if (value instanceof Collection) {
+      final var headerList =
+          ((Collection<Object>) value).stream().map(Object::toString).collect(Collectors.toList());
+
+      return header(name, headerList);
+    }
+
     return value != null ? header(name, value.toString()) : this;
   }
 

--- a/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
@@ -253,7 +253,7 @@ public interface HttpClientRequest {
    * @return The request being built
    */
   default HttpClientRequest queryParam(String name, Collection<String> values) {
-    return queryParam(name, values);
+    return queryParam(name, (Object) values);
   }
 
   /**

--- a/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
@@ -246,6 +246,17 @@ public interface HttpClientRequest {
   HttpClientRequest queryParam(Map<String, ?> params);
 
   /**
+   * Add a query parameter with multiple values
+   *
+   * @param name The name of the query parameter
+   * @param value The values of the query parameter which can be null
+   * @return The request being built
+   */
+  default HttpClientRequest queryParam(String name, Collection<String> values) {
+    return queryParam(name, values);
+  }
+
+  /**
    * Add a form parameter.
    *
    * @param name  The form parameter name

--- a/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
@@ -5,6 +5,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -124,6 +125,15 @@ public interface HttpClientRequest {
    * @return The request being built
    */
   HttpClientRequest header(Map<String, ?> headers);
+
+  /**
+   * Add the headers to the request via Collection.
+   *
+   * @param name The header name
+   * @param value The header values
+   * @return The request being built
+   */
+  HttpClientRequest header(String name, Collection<String> value);
 
   /**
    * Return the header values that have been set for the given header name.

--- a/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
@@ -110,9 +110,10 @@ public interface HttpClientRequest {
   HttpClientRequest header(String name, String value);
 
   /**
-   * Add the header to the request implicitly converting the value to a String.
+   * Add the header to the request implicitly converting the value to a String. If the value is a
+   * collection then it's values are appended with the same key
    *
-   * @param name  The header name
+   * @param name The header name
    * @param value The header value
    * @return The request being built
    */
@@ -228,7 +229,7 @@ public interface HttpClientRequest {
   HttpClientRequest queryParam(String name, String value);
 
   /**
-   * Add a query parameter
+   * Add a query parameter, if value is a collection then it's values are appended with the same key
    *
    * @param name  The name of the query parameter
    * @param value The value of the query parameter which can be null

--- a/http-client/src/main/java/io/avaje/http/client/UrlBuilder.java
+++ b/http-client/src/main/java/io/avaje/http/client/UrlBuilder.java
@@ -2,6 +2,7 @@ package io.avaje.http.client;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -84,6 +85,14 @@ public final class UrlBuilder {
    * The name and value parameters are url encoded.
    */
   public UrlBuilder queryParam(String name, Object value) {
+	  
+    if (value instanceof Collection) {
+      for (var e : (Collection) value) {
+        queryParam(name, e);
+      }
+      return this;
+    }
+    
     if (value != null) {
       addQueryParam(name, value.toString());
     }

--- a/http-client/src/test/java/io/avaje/http/client/DHttpClientRequestTest.java
+++ b/http-client/src/test/java/io/avaje/http/client/DHttpClientRequestTest.java
@@ -1,10 +1,11 @@
 package io.avaje.http.client;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class DHttpClientRequestTest {
 
@@ -19,6 +20,35 @@ class DHttpClientRequestTest {
 
     assertThat(event.requestBody()).isEqualTo("<suppressed request body>");
     assertThat(event.responseBody()).isEqualTo("<suppressed response body>");
+  }
+
+  @Test
+  void assertHeader() {
+    final var request = new DHttpClientRequest(context, Duration.ZERO);
+
+    final var headers =
+        request
+            .header("Accept", (Object) List.of("application/json", "application/json2"))
+            .header("Accept");
+
+    assertThat(headers).asList().contains("application/json", "application/json2");
+  }
+
+  @Test
+  void assertQuery() {
+    final var client = HttpClient.builder().baseUrl("https://ap7i.github.com").build();
+
+    final var uri =
+        client
+            .request()
+            .queryParam("param", List.of("param1", "param2"))
+            .HEAD()
+            .asDiscarding()
+            .request()
+            .uri()
+            .toString();
+
+    assertThat(uri).isEqualTo("https://ap7i.github.com?param=param1&param=param2");
   }
 
   @Test

--- a/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -801,7 +801,7 @@ class HelloControllerTest extends BaseWebTest {
   void get_withPathParamAndQueryParam_returningBean() {
 
     final HelloDto dto = clientContext.request()
-      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", null)
+      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", (Object) null)
       .GET()
       .bean(HelloDto.class);
 
@@ -813,7 +813,7 @@ class HelloControllerTest extends BaseWebTest {
   @Test
   void callBean() {
     final HelloDto dto = clientContext.request()
-      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", null)
+      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", (Object) null)
       .GET()
       .call().bean(HelloDto.class).execute();
 
@@ -825,7 +825,7 @@ class HelloControllerTest extends BaseWebTest {
   @Test
   void callBeanAsync() throws ExecutionException, InterruptedException {
     final CompletableFuture<HelloDto> future = clientContext.request()
-      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", null)
+      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", (String) null)
       .GET()
       .call().bean(HelloDto.class).async();
 
@@ -842,7 +842,7 @@ class HelloControllerTest extends BaseWebTest {
     final AtomicReference<HelloDto> ref = new AtomicReference<>();
 
     final CompletableFuture<HelloDto> future = clientContext.request()
-      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", null)
+      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", (String) null)
       .GET()
       .async().bean(HelloDto.class);
 
@@ -872,7 +872,7 @@ class HelloControllerTest extends BaseWebTest {
     final AtomicReference<HttpResponse<HelloDto>> ref = new AtomicReference<>();
 
     final CompletableFuture<HttpResponse<HelloDto>> future = clientContext.request()
-      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", null)
+      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", (String) null)
       .GET()
       .async().as(HelloDto.class);
 

--- a/tests/test-javalin-jsonb/src/test/java/org/example/myapp/HelloControllerTest.java
+++ b/tests/test-javalin-jsonb/src/test/java/org/example/myapp/HelloControllerTest.java
@@ -96,7 +96,7 @@ class HelloControllerTest extends BaseWebTest {
     assertThat(bean.otherParam).isEqualTo("other");
 
     final HelloDto dto = client.request()
-      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", null)
+      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", (String) null)
       .GET().bean(HelloDto.class);
 
     assertThat(dto.id).isEqualTo(43L);

--- a/tests/test-javalin/src/test/java/org/example/myapp/HelloControllerTest.java
+++ b/tests/test-javalin/src/test/java/org/example/myapp/HelloControllerTest.java
@@ -98,7 +98,7 @@ class HelloControllerTest extends BaseWebTest {
     assertThat(bean.otherParam).isEqualTo("other");
 
     final HelloDto dto = client.request()
-      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", null)
+      .path("hello/43/2020-03-05").queryParam("otherParam", "other").queryParam("foo", (String) null)
       .GET().bean(HelloDto.class);
 
     assertThat(dto.id).isEqualTo(43L);


### PR DESCRIPTION
- adds `header(String, Collection<String>)` and `queryparam(String, Collection<String>)`
- modifies uriBuilder to add multiple query parameters for collections
- modifies query param/header method to detect if the object is a collection  