### PR TITLE
Update Validator Plugin (Jakarta)

### DIFF
--- a/http-hibernate-validator/pom.xml
+++ b/http-hibernate-validator/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>8.12-RC1</version>
+      <version>8.13</version>
       <scope>provided</scope>
     </dependency>
 

--- a/http-hibernate-validator/src/main/java/io/avaje/http/hibernate/validator/ValidatorProvider.java
+++ b/http-hibernate-validator/src/main/java/io/avaje/http/hibernate/validator/ValidatorProvider.java
@@ -15,6 +15,6 @@ public final class ValidatorProvider implements io.avaje.inject.spi.Plugin {
 
   @Override
   public void apply(BeanScopeBuilder builder) {
-    builder.provideDefault(Validator.class, BeanValidator::new);
+    builder.provideDefault(null, Validator.class, BeanValidator::new);
   }
 }


### PR DESCRIPTION
This will prevent the eventual `NoSuchMethod` error when used with inject 9.0. 