### PR TITLE
fix client processor overriding OpenAPI

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -48,7 +48,7 @@ public class ClientProcessor extends AbstractProcessor {
   public synchronized void init(ProcessingEnvironment processingEnv) {
     super.init(processingEnv);
     this.processingEnv = processingEnv;
-    ProcessingContext.init(processingEnv, new ClientPlatformAdapter());
+    ProcessingContext.init(processingEnv, new ClientPlatformAdapter(), false);
   }
 
   @Override

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -37,13 +37,20 @@ public class ProcessingContext {
   private static String diAnnotation;
 
   public static void init(ProcessingEnvironment env, PlatformAdapter adapter) {
+    init(env, adapter, true);
+  }
+
+  public static void init(ProcessingEnvironment env, PlatformAdapter adapter, boolean generateOpenAPI) {
     readAdapter = adapter;
     messager = env.getMessager();
     filer = env.getFiler();
     elements = env.getElementUtils();
     types = env.getTypeUtils();
     openApiAvailable = isTypeAvailable(Constants.OPENAPIDEFINITION);
-    docContext = new DocContext(env, openApiAvailable);
+
+    if (generateOpenAPI) {
+      docContext = new DocContext(env, openApiAvailable);
+    }
 
     final var options = env.getOptions();
     final var singletonOverride = options.get("useSingleton");


### PR DESCRIPTION
I guess the Client Processor would overwrite the DocContext in the processing context

Fixes #174 
