### PR TITLE
OpenAPI documents support enumeration types

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/OpenAPISerializer.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/OpenAPISerializer.java
@@ -81,7 +81,7 @@ final class OpenAPISerializer {
               sb.append(",");
             }
             sb.append("\"");
-            sb.append(field.getName());
+            sb.append(field.getName().replace("_enum", "enum"));
             sb.append("\" : ");
             write(sb, value);
             firstField = false;

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
@@ -165,7 +165,10 @@ class SchemaDocBuilder {
       .forEach(ec -> schema.addEnumItem(ec.getSimpleName().toString()));
 
     var doc = Javadoc.parse(elements.getDocComment(e));
-    schema.setDescription(doc.getDescription());
+    var desc = doc.getDescription();
+    if (desc != null && !desc.isEmpty()) {
+      schema.setDescription(desc);
+    }
     return schema;
   }
 

--- a/tests/test-javalin-jsonb/src/main/resources/public/openapi.json
+++ b/tests/test-javalin-jsonb/src/main/resources/public/openapi.json
@@ -1,18 +1,18 @@
 {
 	"openapi" : "3.0.1",
 	"info" : {
-		"title" : "Example service showing off the Path extension method of controller",
+		"title" : "Example service",
 		"description" : "Example Javalin controllers with Java and Maven",
 		"version" : ""
 	},
 	"tags" : [
 		{
 			"name" : "tag1",
-			"description" : "this is added to openapi tags"
+			"description" : "it's somethin"
 		},
 		{
 			"name" : "tag1",
-			"description" : "it's somethin"
+			"description" : "this is added to openapi tags"
 		}
 	],
 	"paths" : {
@@ -1156,7 +1156,12 @@
 										"type" : "string"
 									},
 									"type" : {
-										"$ref" : "#/components/schemas/ServerType"
+										"type" : "string",
+										"enum" : [
+											"PROXY",
+											"HIDE_N_SEEK",
+											"FFA"
+										]
 									}
 								}
 							}
@@ -1195,7 +1200,12 @@
 										"type" : "string"
 									},
 									"type" : {
-										"$ref" : "#/components/schemas/ServerType"
+										"type" : "string",
+										"enum" : [
+											"PROXY",
+											"HIDE_N_SEEK",
+											"FFA"
+										]
 									}
 								}
 							}
@@ -1229,7 +1239,12 @@
 						"name" : "type",
 						"in" : "query",
 						"schema" : {
-							"$ref" : "#/components/schemas/ServerType"
+							"type" : "string",
+							"enum" : [
+								"PROXY",
+								"HIDE_N_SEEK",
+								"FFA"
+							]
 						}
 					}
 				],
@@ -1261,7 +1276,12 @@
 						"schema" : {
 							"type" : "array",
 							"items" : {
-								"$ref" : "#/components/schemas/ServerType"
+								"type" : "string",
+								"enum" : [
+									"PROXY",
+									"HIDE_N_SEEK",
+									"FFA"
+								]
 							}
 						}
 					}
@@ -1299,7 +1319,12 @@
 						"name" : "type",
 						"in" : "query",
 						"schema" : {
-							"$ref" : "#/components/schemas/ServerType"
+							"type" : "string",
+							"enum" : [
+								"PROXY",
+								"HIDE_N_SEEK",
+								"FFA"
+							]
 						}
 					}
 				],
@@ -1902,9 +1927,6 @@
 						"type" : "string"
 					}
 				}
-			},
-			"ServerType" : {
-				"type" : "object"
 			},
 			"byte" : {
 				"type" : "object"

--- a/tests/test-jex/src/main/java/org/example/web/HelloDto.java
+++ b/tests/test-jex/src/main/java/org/example/web/HelloDto.java
@@ -8,4 +8,5 @@ public class HelloDto {
   public int id;
   @NotNull
   public String name;
+  public ServerType serverType;
 }

--- a/tests/test-jex/src/main/resources/public/openapi.json
+++ b/tests/test-jex/src/main/resources/public/openapi.json
@@ -190,7 +190,12 @@
 						"name" : "type",
 						"in" : "query",
 						"schema" : {
-							"$ref" : "#/components/schemas/ServerType"
+							"type" : "string",
+							"enum" : [
+								"PROXY",
+								"HIDE_N_SEEK",
+								"FFA"
+							]
 						}
 					}
 				],
@@ -222,7 +227,12 @@
 						"schema" : {
 							"type" : "array",
 							"items" : {
-								"$ref" : "#/components/schemas/ServerType"
+								"type" : "string",
+								"enum" : [
+									"PROXY",
+									"HIDE_N_SEEK",
+									"FFA"
+								]
 							}
 						}
 					}
@@ -260,7 +270,12 @@
 						"name" : "type",
 						"in" : "query",
 						"schema" : {
-							"$ref" : "#/components/schemas/ServerType"
+							"type" : "string",
+							"enum" : [
+								"PROXY",
+								"HIDE_N_SEEK",
+								"FFA"
+							]
 						}
 					}
 				],
@@ -363,11 +378,16 @@
 					"name" : {
 						"type" : "string",
 						"nullable" : false
+					},
+					"serverType" : {
+						"type" : "string",
+						"enum" : [
+							"PROXY",
+							"HIDE_N_SEEK",
+							"FFA"
+						]
 					}
 				}
-			},
-			"ServerType" : {
-				"type" : "object"
 			}
 		}
 	}


### PR DESCRIPTION
![微信截图_20230309104611](https://user-images.githubusercontent.com/4236414/223903148-8f79839d-ba2c-4005-8e0f-8881beb7e15e.png)

I tried to add support for enumeration types in the OpenAPI document, but the current JSON cannot handle it correctly. Whether to consider introducing swagger core to support document processing? I feel this is necessary.