### PR TITLE
(Http-Client) Support Jsonb SubTypes in request body

### DIFF
--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -29,21 +29,21 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.1</version>
+      <version>2.14.2</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
-      <version>1.1</version>
+      <version>1.3</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>8.12-RC1</version>
+      <version>8.13</version>
       <optional>true</optional>
     </dependency>
 

--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -265,8 +265,8 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
     return httpClient.sendAsync(requestBuilder.build(), bodyHandler);
   }
 
-  <T> BodyContent write(T bean, String contentType) {
-    return bodyAdapter.beanWriter(bean.getClass()).write(bean, contentType);
+  <T> BodyContent write(T bean, Class<?> type, String contentType) {
+    return bodyAdapter.beanWriter(type).write(bean, contentType);
   }
 
   <T> BodyReader<T> beanReader(Class<T> type) {

--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
@@ -266,14 +266,25 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
   }
 
   @Override
-  public HttpClientRequest body(Object bean, String contentType) {
-    encodedRequestBody = context.write(bean, contentType);
-    return this;
+  public HttpClientRequest body(Object bean) {
+    return body(bean, bean.getClass(), null);
   }
 
   @Override
-  public HttpClientRequest body(Object bean) {
-    return body(bean, null);
+  public HttpClientRequest body(Object bean, String contentType) {
+
+    return body(bean, bean.getClass(), contentType);
+  }
+
+  @Override
+  public HttpClientRequest body(Object bean, Class<?> type) {
+    return body(bean, type, null);
+  }
+
+  @Override
+  public HttpClientRequest body(Object bean, Class<?> type, String contentType) {
+    encodedRequestBody = context.write(bean, type, contentType);
+    return this;
   }
 
   @Override

--- a/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
@@ -299,6 +299,17 @@ public interface HttpClientRequest {
   HttpClientRequest body(Object bean);
 
   /**
+   * Set the body as a bean with the given content type using a BodyWriter.
+   * Used for JsonbAdapter
+   */
+  HttpClientRequest body(Object bean, Class<?> type);
+
+  /**
+   * Set the body as a bean with the given content type using a BodyWriter.
+   */
+  HttpClientRequest body(Object bean, Class<?> type, String contentType);
+
+  /**
    * Set the body content as a string.
    *
    * @param body The body content

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -251,7 +251,7 @@ private void writeEnd() {
     for (MethodParam param : method.params()) {
       ParamType paramType = param.paramType();
       if (paramType == ParamType.BODY) {
-        writer.append("      .body(%s)", param.name()).eol();
+        writer.append("      .body(%s, %s.class)", param.name(), param.utype().shortType()).eol();
       }
     }
   }

--- a/http-generator-core/pom.xml
+++ b/http-generator-core/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-prisms</artifactId>
-      <version>1.5</version>
+      <version>1.6</version>
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
@@ -81,7 +81,7 @@
             <path>
               <groupId>io.avaje</groupId>
               <artifactId>avaje-prisms</artifactId>
-              <version>1.5</version>
+              <version>1.6</version>
             </path>
           </annotationProcessorPaths>
         </configuration>


### PR DESCRIPTION
The use of `.getClass()` means that jsonb subtypes cannot work.

```
@Client
public interface Client {

  @Post("/resource")
  public Response createResource(ExtendableObject object);

}
```

Providing an `ExtendingObject` that extends ExtendableObject means that the JsonAdapter for ExtendableObject is not used, so the `@type` field is lost. This PR fixes that.

- Adds new `body` methods to HttpClientRequest to take the type parameter
- now generated clients will provide the type parameters

