### PR TITLE
Use Context#bodyStreamAsClass(...)

### DIFF
--- a/http-client/src/test/java/org/example/webserver/HelloController$Route.java
+++ b/http-client/src/test/java/org/example/webserver/HelloController$Route.java
@@ -64,7 +64,7 @@ public class HelloController$Route implements WebRoutes {
 
     ApiBuilder.post("/hello", ctx -> {
       ctx.status(201);
-      HelloDto dto = ctx.bodyStreamAsClass(HelloDto.class);
+      HelloDto dto = ctx.bodyAsClass(HelloDto.class);
       validator.validate(dto);
       ctx.json(controller.post(dto));
     });
@@ -72,7 +72,7 @@ public class HelloController$Route implements WebRoutes {
     ApiBuilder.post("/hello/savebean/{foo}", ctx -> {
       ctx.status(201);
       String foo = ctx.pathParam("foo");
-      HelloDto dto = ctx.bodyStreamAsClass(HelloDto.class);
+      HelloDto dto = ctx.bodyAsClass(HelloDto.class);
       validator.validate(dto);
       controller.saveBean(foo, dto, ctx);
     });

--- a/http-client/src/test/java/org/example/webserver/HelloController$Route.java
+++ b/http-client/src/test/java/org/example/webserver/HelloController$Route.java
@@ -64,7 +64,7 @@ public class HelloController$Route implements WebRoutes {
 
     ApiBuilder.post("/hello", ctx -> {
       ctx.status(201);
-      HelloDto dto = ctx.bodyAsClass(HelloDto.class);
+      HelloDto dto = ctx.bodyStreamAsClass(HelloDto.class);
       validator.validate(dto);
       ctx.json(controller.post(dto));
     });
@@ -72,7 +72,7 @@ public class HelloController$Route implements WebRoutes {
     ApiBuilder.post("/hello/savebean/{foo}", ctx -> {
       ctx.status(201);
       String foo = ctx.pathParam("foo");
-      HelloDto dto = ctx.bodyAsClass(HelloDto.class);
+      HelloDto dto = ctx.bodyStreamAsClass(HelloDto.class);
       validator.validate(dto);
       controller.saveBean(foo, dto, ctx);
     });

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinAdapter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinAdapter.java
@@ -39,7 +39,7 @@ class JavalinAdapter implements PlatformAdapter {
       if (useJsonB) {
         return type.shortName() + "JsonType.fromJson(ctx.bodyInputStream())";
       }
-      return "ctx.bodyAsClass(" + type.mainType() + ".class)";
+      return "ctx.bodyStreamAsClass(" + type.mainType() + ".class)";
     }
   }
 


### PR DESCRIPTION
Use Javalin's `Context#bodyStreamAsClass` method to deserialize rather than `Context#bodyAsClass`.

### Drawbacks
If one would like to make a custom `io.javalin.json.JsonMapper`, they MUST override not only `toJsonString` and `fromJsonString` (well, no longer need to override those two, but probably would also override those two), but also `toJsonStream` and `fromJsonStream`, or an exception will be thrown when deserializing.

### Motivation
- This approach means deserialization will not eat memory for large inputs and also allows for input validation to be more powerful 
- Means users of non-JSON codecs like https://msgpack.org can use the powerful features more efficiently, e.g. reading a binary byte array could be done with an InputStream inside of a POJO being read from, so instead of having to send the binary data separately to any other data needed alongside it, you could have it as the last field inside of the POJO and then stream in the POJO, do whatever validation you need to do, maybe even stream out your input so the binary data is never fully loaded in memory and is just streamed through some processing logic and you can have an output.
For example, if I was going to make a route to resize an image, and I wanted to have the new dimensions as part of the POJO (ie the JSON) rather than a path parameter or something, so my object looked like `{ width: number, height: number, image: binary }`, I could stream the new image out and have the width and height on hand all with one request.
- Means users of JSON could also do the same thing! While yes, JSON doesn't have a proper binary data format, you can safely just use Base64 in strings for everything, even file uploads; while yes, Base64 results in a 33% size increase to regular binary data, compression with e.g. gzip would result in this being completely negligible and quite honestly, I personally find this approach to allow for much more modern REST APIs than would normally be attained by e.g. form data.

