### PR TITLE
Add @Ignore for ignoring a BeanParam field (or query param field)

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/Ignore.java
+++ b/http-api/src/main/java/io/avaje/http/api/Ignore.java
@@ -9,4 +9,4 @@ import java.lang.annotation.Target;
 /** Mark a field on a BeanParam/FormParam class as not a request parameter of any kind */
 @Target(FIELD)
 @Retention(SOURCE)
-public @interface IgnoreBeanField {}
+public @interface Ignore {}

--- a/http-api/src/main/java/io/avaje/http/api/IgnoreBeanField.java
+++ b/http-api/src/main/java/io/avaje/http/api/IgnoreBeanField.java
@@ -1,0 +1,12 @@
+package io.avaje.http.api;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** Mark a field on a BeanParam/FormParam class as not a request parameter of any kind */
+@Target(FIELD)
+@Retention(SOURCE)
+public @interface IgnoreBeanField {}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BeanParamReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BeanParamReader.java
@@ -41,7 +41,7 @@ public class BeanParamReader {
 
   private void readField(Element enclosedElement) {
 
-    if (IgnoreBeanFieldPrism.isPresent(enclosedElement)) {
+    if (IgnorePrism.isPresent(enclosedElement)) {
       return;
     }
     FieldReader field = new FieldReader(enclosedElement, defaultParamType);

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BeanParamReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BeanParamReader.java
@@ -40,6 +40,10 @@ public class BeanParamReader {
   }
 
   private void readField(Element enclosedElement) {
+
+    if (IgnoreBeanFieldPrism.isPresent(enclosedElement)) {
+      return;
+    }
     FieldReader field = new FieldReader(enclosedElement, defaultParamType);
     fieldMap.put(field.varName(), field);
   }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
@@ -1,7 +1,7 @@
 /** Generate the prisms to access annotation info */
 @GeneratePrism(value = io.avaje.http.api.Controller.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.BeanParam.class, publicAccess = true)
-@GeneratePrism(value = io.avaje.http.api.IgnoreBeanField.class, publicAccess = true)
+@GeneratePrism(value = io.avaje.http.api.Ignore.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.QueryParam.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Client.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Cookie.class, publicAccess = true)

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
@@ -1,6 +1,7 @@
 /** Generate the prisms to access annotation info */
 @GeneratePrism(value = io.avaje.http.api.Controller.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.BeanParam.class, publicAccess = true)
+@GeneratePrism(value = io.avaje.http.api.IgnoreBeanField.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.QueryParam.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Client.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Cookie.class, publicAccess = true)

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/GetBeanForm.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/GetBeanForm.java
@@ -9,10 +9,9 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import io.avaje.http.api.Header;
-import io.avaje.http.api.IgnoreBeanField;
+import io.avaje.http.api.Ignore;
 import io.avaje.http.api.QueryParam;
 import io.avaje.jsonb.Json;
-import io.avaje.jsonb.Json.Ignore;
 
 @Json
 @Valid
@@ -32,7 +31,7 @@ public class GetBeanForm {
 
   @QueryParam private Set<ServerType> type;
 
-  @Ignore @IgnoreBeanField private String ignored;
+  @Json.Ignore @Ignore private String ignored;
 
   public String getIgnored() {
     return ignored;

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/GetBeanForm.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/GetBeanForm.java
@@ -9,8 +9,10 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import io.avaje.http.api.Header;
+import io.avaje.http.api.IgnoreBeanField;
 import io.avaje.http.api.QueryParam;
 import io.avaje.jsonb.Json;
+import io.avaje.jsonb.Json.Ignore;
 
 @Json
 @Valid
@@ -29,6 +31,12 @@ public class GetBeanForm {
   @Header private String head;
 
   @QueryParam private Set<ServerType> type;
+
+  @Ignore @IgnoreBeanField private String ignored;
+
+  public String getIgnored() {
+    return ignored;
+  }
 
   public String getName() {
     return name;


### PR DESCRIPTION
Also adds an @Ignore annotation for bean parameters. (have a case where I use the bean param object constructors to initialize other useful fields that are not expected parameters).

It's like a `Jsonb.Ignore(serialization=true)` but for http.