### PR TITLE
[http client] Change Async API to use more generic Type instead of ParameterizedType 

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/DHttpAsync.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpAsync.java
@@ -1,7 +1,7 @@
 package io.avaje.http.client;
 
 import java.io.InputStream;
-import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -65,7 +65,7 @@ final class DHttpAsync implements HttpAsyncResponse {
   }
 
   @Override
-  public <E> CompletableFuture<E> bean(ParameterizedType type) {
+  public <E> CompletableFuture<E> bean(Type type) {
     final CompletableFuture<HttpResponse<E>> future = as(type);
     return future.thenApply(HttpResponse::body);
   }
@@ -76,7 +76,7 @@ final class DHttpAsync implements HttpAsyncResponse {
   }
 
   @Override
-  public <E> CompletableFuture<HttpResponse<E>> as(ParameterizedType type) {
+  public <E> CompletableFuture<HttpResponse<E>> as(Type type) {
     return asyncAsBytes().thenApply(httpResponse -> request.asyncBean(type, httpResponse));
   }
 
@@ -86,7 +86,7 @@ final class DHttpAsync implements HttpAsyncResponse {
   }
 
   @Override
-  public <E> CompletableFuture<List<E>> list(ParameterizedType type) {
+  public <E> CompletableFuture<List<E>> list(Type type) {
     final CompletableFuture<HttpResponse<List<E>>> future = asList(type);
     return future.thenApply(HttpResponse::body);
   }
@@ -97,7 +97,7 @@ final class DHttpAsync implements HttpAsyncResponse {
   }
 
   @Override
-  public <E> CompletableFuture<HttpResponse<List<E>>> asList(ParameterizedType type) {
+  public <E> CompletableFuture<HttpResponse<List<E>>> asList(Type type) {
     return asyncAsBytes().thenApply(httpResponse -> request.asyncList(type, httpResponse));
   }
 
@@ -107,7 +107,7 @@ final class DHttpAsync implements HttpAsyncResponse {
   }
 
   @Override
-  public <E> CompletableFuture<Stream<E>> stream(ParameterizedType type) {
+  public <E> CompletableFuture<Stream<E>> stream(Type type) {
     final CompletableFuture<HttpResponse<Stream<E>>> future = asStream(type);
     return future.thenApply(HttpResponse::body);
   }
@@ -118,7 +118,7 @@ final class DHttpAsync implements HttpAsyncResponse {
   }
 
   @Override
-  public <E> CompletableFuture<HttpResponse<Stream<E>>> asStream(ParameterizedType type) {
+  public <E> CompletableFuture<HttpResponse<Stream<E>>> asStream(Type type) {
     return asyncAsLines().thenApply(httpResponse -> request.asyncStream(type, httpResponse));
   }
 

--- a/http-client/src/main/java/io/avaje/http/client/DHttpCall.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpCall.java
@@ -1,7 +1,7 @@
 package io.avaje.http.client;
 
 import java.io.InputStream;
-import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -61,7 +61,7 @@ final class DHttpCall implements HttpCallResponse {
   }
 
   @Override
-  public <E> HttpCall<HttpResponse<E>> as(ParameterizedType type) {
+  public <E> HttpCall<HttpResponse<E>> as(Type type) {
     return new CallAs<>(type);
   }
 
@@ -71,7 +71,7 @@ final class DHttpCall implements HttpCallResponse {
   }
 
   @Override
-  public <E> HttpCall<HttpResponse<List<E>>> asList(ParameterizedType type) {
+  public <E> HttpCall<HttpResponse<List<E>>> asList(Type type) {
     return new CallAsList<>(type);
   }
 
@@ -81,7 +81,7 @@ final class DHttpCall implements HttpCallResponse {
   }
 
   @Override
-  public <E> HttpCall<HttpResponse<Stream<E>>> asStream(ParameterizedType type) {
+  public <E> HttpCall<HttpResponse<Stream<E>>> asStream(Type type) {
     return new CallAsStream<>(type);
   }
 
@@ -96,17 +96,17 @@ final class DHttpCall implements HttpCallResponse {
   }
 
   @Override
-  public <E> HttpCall<E> bean(ParameterizedType type) {
+  public <E> HttpCall<E> bean(Type type) {
     return new CallBean<>(type);
   }
 
   @Override
-  public <E> HttpCall<List<E>> list(ParameterizedType type) {
+  public <E> HttpCall<List<E>> list(Type type) {
     return new CallList<>(type);
   }
 
   @Override
-  public <E> HttpCall<Stream<E>> stream(ParameterizedType type) {
+  public <E> HttpCall<Stream<E>> stream(Type type) {
     return new CallStream<>(type);
   }
 
@@ -184,7 +184,7 @@ final class DHttpCall implements HttpCallResponse {
 
   private class CallAs<E> implements HttpCall<HttpResponse<E>> {
     private final Class<E> type;
-    private final ParameterizedType genericType;
+    private final Type genericType;
     private final boolean isGeneric;
 
     CallAs(Class<E> type) {
@@ -193,7 +193,7 @@ final class DHttpCall implements HttpCallResponse {
       this.genericType = null;
     }
 
-    CallAs(ParameterizedType type) {
+    CallAs(Type type) {
       this.isGeneric = true;
       this.type = null;
       this.genericType = type;
@@ -212,7 +212,7 @@ final class DHttpCall implements HttpCallResponse {
 
   private class CallAsList<E> implements HttpCall<HttpResponse<List<E>>> {
     private final Class<E> type;
-    private final ParameterizedType genericType;
+    private final Type genericType;
     private final boolean isGeneric;
 
     CallAsList(Class<E> type) {
@@ -221,7 +221,7 @@ final class DHttpCall implements HttpCallResponse {
       this.genericType = null;
     }
 
-    CallAsList(ParameterizedType type) {
+    CallAsList(Type type) {
       this.isGeneric = true;
       this.type = null;
       this.genericType = type;
@@ -240,7 +240,7 @@ final class DHttpCall implements HttpCallResponse {
 
   private class CallAsStream<E> implements HttpCall<HttpResponse<Stream<E>>> {
     private final Class<E> type;
-    private final ParameterizedType genericType;
+    private final Type genericType;
     private final boolean isGeneric;
 
     CallAsStream(Class<E> type) {
@@ -249,7 +249,7 @@ final class DHttpCall implements HttpCallResponse {
       this.genericType = null;
     }
 
-    CallAsStream(ParameterizedType type) {
+    CallAsStream(Type type) {
       this.isGeneric = true;
       this.type = null;
       this.genericType = type;
@@ -268,7 +268,7 @@ final class DHttpCall implements HttpCallResponse {
 
   private class CallBean<E> implements HttpCall<E> {
     private final Class<E> type;
-    private final ParameterizedType genericType;
+    private final Type genericType;
     private final boolean isGeneric;
 
     CallBean(Class<E> type) {
@@ -277,7 +277,7 @@ final class DHttpCall implements HttpCallResponse {
       this.genericType = null;
     }
 
-    CallBean(ParameterizedType type) {
+    CallBean(Type type) {
       this.isGeneric = true;
       this.type = null;
       this.genericType = type;
@@ -296,7 +296,7 @@ final class DHttpCall implements HttpCallResponse {
 
   private class CallList<E> implements HttpCall<List<E>> {
     private final Class<E> type;
-    private final ParameterizedType genericType;
+    private final Type genericType;
     private final boolean isGeneric;
 
     CallList(Class<E> type) {
@@ -305,7 +305,7 @@ final class DHttpCall implements HttpCallResponse {
       this.genericType = null;
     }
 
-    CallList(ParameterizedType type) {
+    CallList(Type type) {
       this.isGeneric = true;
       this.type = null;
       this.genericType = type;
@@ -324,7 +324,7 @@ final class DHttpCall implements HttpCallResponse {
 
   private class CallStream<E> implements HttpCall<Stream<E>> {
     private final Class<E> type;
-    private final ParameterizedType genericType;
+    private final Type genericType;
     private final boolean isGeneric;
 
     CallStream(Class<E> type) {
@@ -333,7 +333,7 @@ final class DHttpCall implements HttpCallResponse {
       this.genericType = null;
     }
 
-    CallStream(ParameterizedType type) {
+    CallStream(Type type) {
       this.isGeneric = true;
       this.type = null;
       this.genericType = type;

--- a/http-client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
@@ -1,7 +1,7 @@
 package io.avaje.http.client;
 
 import java.io.InputStream;
-import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -270,7 +270,7 @@ public interface HttpAsyncResponse {
   /**
    * The same as {@link #as(Class)} but using a generic type.
    */
-  <E> CompletableFuture<HttpResponse<E>> as(ParameterizedType type);
+  <E> CompletableFuture<HttpResponse<E>> as(Type type);
 
   /**
    * Process expecting a bean response body (typically from json content).
@@ -346,7 +346,7 @@ public interface HttpAsyncResponse {
   /**
    * The same as {@link #asList(Class)} but using a generic type.
    */
-  <E> CompletableFuture<HttpResponse<List<E>>> asList(ParameterizedType type);
+  <E> CompletableFuture<HttpResponse<List<E>>> asList(Type type);
 
   /**
    * Process expecting a list of beans response body (typically from json content).
@@ -419,7 +419,7 @@ public interface HttpAsyncResponse {
   /**
    * The same as {@link #asStream(Class)} but using a generic type.
    */
-  <E> CompletableFuture<HttpResponse<Stream<E>>> asStream(ParameterizedType type);
+  <E> CompletableFuture<HttpResponse<Stream<E>>> asStream(Type type);
 
   /**
    * Process response as a stream of beans (x-json-stream).
@@ -463,25 +463,25 @@ public interface HttpAsyncResponse {
   /**
    * Process expecting a bean response body (typically from json content).
    *
-   * @param type The parameterized type to convert the content to
+   * @param type The type to convert the content to
    * @return The CompletableFuture of the response
    */
-  <E> CompletableFuture<E> bean(ParameterizedType type);
+  <E> CompletableFuture<E> bean(Type type);
 
   /**
    * Process expecting a list of beans response body (typically from json content).
    *
-   * @param type The parameterized type to convert the content to
+   * @param type The type to convert the content to
    * @return The CompletableFuture of the response
    */
-  <E> CompletableFuture<List<E>> list(ParameterizedType type);
+  <E> CompletableFuture<List<E>> list(Type type);
 
   /**
    * Process response as a stream of beans (x-json-stream).
    *
-   * @param type The parameterized type to convert the content to
+   * @param type The type to convert the content to
    * @return The CompletableFuture of the response
    */
-  <E> CompletableFuture<Stream<E>> stream(ParameterizedType type);
+  <E> CompletableFuture<Stream<E>> stream(Type type);
 
 }

--- a/http-client/src/main/java/io/avaje/http/client/HttpCallResponse.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpCallResponse.java
@@ -1,7 +1,7 @@
 package io.avaje.http.client;
 
 import java.io.InputStream;
-import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.stream.Stream;
@@ -150,7 +150,7 @@ public interface HttpCallResponse {
   /**
    * Same as {@link #as(Class)} but takes a generic parameterized type.
    */
-  <E> HttpCall<HttpResponse<E>> as(ParameterizedType type);
+  <E> HttpCall<HttpResponse<E>> as(Type type);
 
   /**
    * Same as {@link #as(Class)} but returns {@code HttpResponse<List<E>>}.
@@ -160,7 +160,7 @@ public interface HttpCallResponse {
   /**
    * Same as {@link #as(Class)} but returns {@code HttpResponse<List<E>>}.
    */
-  <E> HttpCall<HttpResponse<List<E>>> asList(ParameterizedType type);
+  <E> HttpCall<HttpResponse<List<E>>> asList(Type type);
 
   /**
    * Same as {@link #as(Class)} but returns {@code HttpResponse<Stream<E>>}.
@@ -170,7 +170,7 @@ public interface HttpCallResponse {
   /**
    * Same as {@link #as(Class)} but returns {@code HttpResponse<Stream<E>>}.
    */
-  <E> HttpCall<HttpResponse<Stream<E>>> asStream(ParameterizedType type);
+  <E> HttpCall<HttpResponse<Stream<E>>> asStream(Type type);
 
   /**
    * A bean response to execute async or sync.
@@ -239,7 +239,7 @@ public interface HttpCallResponse {
    * @param type The parameterized type to convert the content to
    * @return The HttpCall to allow sync or async execution
    */
-  <E> HttpCall<E> bean(ParameterizedType type);
+  <E> HttpCall<E> bean(Type type);
 
   /**
    * Process expecting a list of beans response body (typically from json content).
@@ -247,7 +247,7 @@ public interface HttpCallResponse {
    * @param type The parameterized type to convert the content to
    * @return The HttpCall to execute sync or async
    */
-  <E> HttpCall<List<E>> list(ParameterizedType type);
+  <E> HttpCall<List<E>> list(Type type);
 
   /**
    * Process expecting a stream of beans response body (typically from json content).
@@ -255,6 +255,6 @@ public interface HttpCallResponse {
    * @param type The parameterized type to convert the content to
    * @return The HttpCall to execute sync or async
    */
-  <E> HttpCall<Stream<E>> stream(ParameterizedType type);
+  <E> HttpCall<Stream<E>> stream(Type type);
 
 }

--- a/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClientRequest.java
@@ -321,7 +321,7 @@ public interface HttpClientRequest {
    * a type that is known to JsonbAdapter / the body content adapter used.
    *
    * @param bean The body content as an instance
-   * @param type The parameterized type used by the body content adapter to write the body content
+   * @param type The type used by the body content adapter to write the body content
    * @return The request being built
    */
   HttpClientRequest body(Object bean, Type type);

--- a/http-client/src/main/java/io/avaje/http/client/HttpClientResponse.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClientResponse.java
@@ -74,12 +74,12 @@ public interface HttpClientResponse {
   <T> HttpResponse<T> as(Class<T> type);
 
   /**
-   * Return the response with the body containing a single instance of the given parameterized type.
+   * Return the response with the body containing a single instance of the given type.
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
    * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
-   * @param type The parameterized type of the bean to convert the response content into.
+   * @param type The type of the bean to convert the response content into.
    * @return The response containing the converted body.
    * @throws HttpException when the response has error status codes
    */
@@ -99,7 +99,7 @@ public interface HttpClientResponse {
   <T> HttpResponse<List<T>> asList(Class<T> type);
 
   /**
-   * Return the response with the body containing a list of the given parameterized type.
+   * Return the response with the body containing a list of the given type.
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
    * the HttpResponse. This is the cause in the CompletionException when using an async request.
@@ -133,7 +133,7 @@ public interface HttpClientResponse {
   <T> HttpResponse<Stream<T>> asStream(Class<T> type);
 
   /**
-   * Return the response with the body containing a stream of beans of the given parameterized type.
+   * Return the response with the body containing a stream of beans of the given type.
    * <p>
    * Typically the response is expected to be {@literal application/x-json-stream}
    * newline delimited json payload.
@@ -206,7 +206,7 @@ public interface HttpClientResponse {
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
    * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
-   * @param type The parameterized type of the bean to convert the response content into.
+   * @param type The type of the bean to convert the response content into.
    * @return The bean the response is converted into.
    * @throws HttpException when the response has error status codes
    */
@@ -218,7 +218,7 @@ public interface HttpClientResponse {
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
    * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
-   * @param type The parameterized type of the bean to convert the response content into.
+   * @param type The type of the bean to convert the response content into.
    * @return The list of beans the response is converted into.
    * @throws HttpException when the response has error status codes
    */
@@ -238,7 +238,7 @@ public interface HttpClientResponse {
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
    * the HttpResponse. This is the cause in the CompletionException when using an async request.
    *
-   * @param type The parameterized type of the bean to convert the response content into.
+   * @param type The type of the bean to convert the response content into.
    * @return The stream of beans from the response
    * @throws HttpException when the response has error status codes
    */


### PR DESCRIPTION
Updates JavaDoc and updates the Async Interfaces to use Type