### PR TITLE
Consumes annotation

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/Consumes.java
+++ b/http-api/src/main/java/io/avaje/http/api/Consumes.java
@@ -1,0 +1,35 @@
+package io.avaje.http.api;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Specify endpoint request media type for the generated OpenAPI json.
+ *
+ * <p>When not specified the default MediaType is application/json, so we specify this on
+ * controllers or methods where the responses return a different media type.
+ *
+ * <pre>{@code
+ * @Path("/customers")
+ * @Consumes(MediaType.TEXT_PLAIN)
+ * class CustomerController {
+ *   ...
+ * }
+ *
+ * }</pre>
+ */
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface Consumes {
+
+  /**
+   * Specify request media type.
+   *
+   * <p>When not specified the default MediaType is application/json
+   */
+  String value() default MediaType.APPLICATION_JSON;
+}

--- a/http-api/src/main/java/io/avaje/http/api/Produces.java
+++ b/http-api/src/main/java/io/avaje/http/api/Produces.java
@@ -10,7 +10,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Specify endpoint response media type.
  *
- * When not specified the default MediaType is APPLICATION_JSON
+ * When not specified the default MediaType is application/json,
  * so we specify this on controllers or methods where the responses
  * return a different media type.
  *
@@ -24,14 +24,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * }</pre>
  */
-@Target(value = {TYPE, METHOD})
-@Retention(value = RUNTIME)
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
 public @interface Produces {
 
   /**
    * Specify response media type.
    *
-   * <p>When not specified the default MediaType is APPLICATION_JSON
+   * <p>When not specified the default MediaType is application/json
    */
   String value() default MediaType.APPLICATION_JSON;
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
@@ -1,8 +1,10 @@
 package io.avaje.http.generator.core;
 
-import static io.avaje.http.generator.core.ProcessingContext.*;
-import io.avaje.http.generator.core.javadoc.Javadoc;
-import io.avaje.http.generator.core.openapi.MethodDocBuilder;
+import static io.avaje.http.generator.core.ProcessingContext.doc;
+import static io.avaje.http.generator.core.ProcessingContext.docComment;
+import static io.avaje.http.generator.core.ProcessingContext.platform;
+import static io.avaje.http.generator.core.ProcessingContext.superMethods;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,6 +14,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -19,6 +22,9 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+
+import io.avaje.http.generator.core.javadoc.Javadoc;
+import io.avaje.http.generator.core.openapi.MethodDocBuilder;
 
 public class MethodReader {
 
@@ -53,8 +59,13 @@ public class MethodReader {
     this.actualParams = (actualExecutable == null) ? null : actualExecutable.getParameterTypes();
     this.isVoid = element.getReturnType().getKind() == TypeKind.VOID;
     this.methodRoles = Util.findRoles(element);
-    this.producesAnnotation = findAnnotation(ProducesPrism::getOptionalOn);
-    this.consumesAnnotation = findAnnotation(ConsumesPrism::getOptionalOn);
+    this.producesAnnotation =
+        findAnnotation(ProducesPrism::getOptionalOn)
+            .or(() -> ProducesPrism.getOptionalOn(bean.beanType()));
+    this.consumesAnnotation =
+        findAnnotation(ConsumesPrism::getOptionalOn)
+            .or(() -> ConsumesPrism.getOptionalOn(bean.beanType()));
+
     initWebMethodViaAnnotation();
 
     this.superMethods =

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
@@ -32,6 +32,7 @@ public class MethodReader {
    */
   private final List<String> methodRoles;
   private final Optional<ProducesPrism> producesAnnotation;
+  private final Optional<ConsumesPrism> consumesAnnotation;
   private final List<SecurityRequirementPrism> securityRequirements;
   private final List<OpenAPIResponsePrism> apiResponses;
   private final ExecutableType actualExecutable;
@@ -53,6 +54,7 @@ public class MethodReader {
     this.isVoid = element.getReturnType().getKind() == TypeKind.VOID;
     this.methodRoles = Util.findRoles(element);
     this.producesAnnotation = findAnnotation(ProducesPrism::getOptionalOn);
+    this.consumesAnnotation = findAnnotation(ConsumesPrism::getOptionalOn);
     initWebMethodViaAnnotation();
 
     this.superMethods =
@@ -301,6 +303,10 @@ public class MethodReader {
 
   public String produces() {
     return producesAnnotation.map(ProducesPrism::value).orElseGet(bean::produces);
+  }
+
+  public Optional<ConsumesPrism> consumesAnnotation() {
+    return consumesAnnotation;
   }
 
   public List<SecurityRequirementPrism> securityRequirements() {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/DocContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/DocContext.java
@@ -102,8 +102,8 @@ public class DocContext {
     schemaBuilder.addFormParam(operation, varName, schema);
   }
 
-  void addRequestBody(Operation operation, Schema schema, boolean asForm, String description) {
-    schemaBuilder.addRequestBody(operation, schema, asForm, description);
+  void addRequestBody(Operation operation, Schema schema, String mediaType, String description) {
+    schemaBuilder.addRequestBody(operation, schema, mediaType, description);
   }
 
   /**

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/KnownTypes.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/KnownTypes.java
@@ -1,6 +1,7 @@
 package io.avaje.http.generator.core.openapi;
 
 import java.io.File;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
@@ -46,6 +47,7 @@ class KnownTypes {
     add(new IntegerType(), Integer.class);
     add(new PLongType(), long.class);
     add(new LongType(), Long.class);
+    add(new BytesType(), byte[].class, InputStream.class);
 
     add(new PNumberType(), double.class, float.class);
     add(new NumberType(), Double.class, Float.class, BigDecimal.class, BigInteger.class);
@@ -171,6 +173,12 @@ class KnownTypes {
   private class URIType extends StringBaseType {
     private URIType() {
       super("uri");
+    }
+  }
+
+  private class BytesType extends StringBaseType {
+    private BytesType() {
+      super("byte");
     }
   }
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodDocBuilder.java
@@ -1,5 +1,8 @@
 package io.avaje.http.generator.core.openapi;
 
+import java.util.Optional;
+
+import io.avaje.http.generator.core.ConsumesPrism;
 import io.avaje.http.generator.core.HiddenPrism;
 import io.avaje.http.generator.core.MethodParam;
 import io.avaje.http.generator.core.MethodReader;
@@ -21,11 +24,13 @@ public class MethodDocBuilder {
   private final DocContext ctx;
 
   private final Operation operation = new Operation();
+  private Optional<ConsumesPrism> consumeOp;
 
   public MethodDocBuilder(MethodReader methodReader, DocContext ctx) {
     this.methodReader = methodReader;
     this.ctx = ctx;
     this.javadoc = methodReader.javadoc();
+    this.consumeOp = methodReader.consumesAnnotation();
   }
 
   public void build() {
@@ -127,6 +132,10 @@ public class MethodDocBuilder {
 
   Operation getOperation() {
     return operation;
+  }
+
+  public Optional<ConsumesPrism> consumeOp() {
+    return consumeOp;
   }
 
   private boolean isEmpty(String value) {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
@@ -102,18 +102,15 @@ class SchemaDocBuilder {
     return schema;
   }
 
-  /**
-   * Add as request body.
-   */
-  void addRequestBody(Operation operation, Schema schema, boolean asForm, String description) {
+  /** Add as request body. */
+  void addRequestBody(Operation operation, Schema schema, String mediaType, String description) {
     RequestBody body = requestBody(operation);
     body.setDescription(description);
 
     MediaType mt = new MediaType();
     mt.schema(schema);
 
-    String mime = asForm ? APP_FORM : APP_JSON;
-    body.getContent().addMediaType(mime, mt);
+    body.getContent().addMediaType(mediaType, mt);
   }
 
   private RequestBody requestBody(Operation operation) {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
@@ -16,6 +16,7 @@
 @GeneratePrism(value = io.avaje.http.api.Path.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Post.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Produces.class, publicAccess = true)
+@GeneratePrism(value = io.avaje.http.api.Consumes.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Put.class, publicAccess = true)
 @GeneratePrism(value = io.swagger.v3.oas.annotations.OpenAPIDefinition.class, publicAccess = true)
 @GeneratePrism(value = io.swagger.v3.oas.annotations.tags.Tag.class, publicAccess = true)

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController2.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController2.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.example.myapp.web.ServerType;
 
+import io.avaje.http.api.Consumes;
 import io.avaje.http.api.Controller;
 import io.avaje.http.api.Default;
 import io.avaje.http.api.Form;
@@ -46,6 +47,7 @@ public class TestController2 {
   }
 
   @Get("/inputStream")
+  @Consumes("application/bson")
   String stream(InputStream stream) {
     return stream.toString();
   }


### PR DESCRIPTION
- Adds an annotation to tell what media type the request body should be
- fix produces not working on a class level
- byte[] and inputstream now generate correct openAPI format