### PR TITLE
Don't export SPI package

### DIFF
--- a/http-api/src/main/java/module-info.java
+++ b/http-api/src/main/java/module-info.java
@@ -2,7 +2,6 @@ module io.avaje.http.api {
 
 	exports io.avaje.http.api;
 	exports io.avaje.http.api.context;
-	exports io.avaje.http.api.spi;
 	requires static io.avaje.inject;
 
 	provides io.avaje.inject.spi.Plugin with io.avaje.http.api.spi.DefaultResolverProvider;


### PR DESCRIPTION
We don't need it to service load.

EDIT: Ahh, but hmm, if the module thing doesn't/won't get fixed we will need to export it.