### PR TITLE
Don't serialize twice when Javalin Context is already committed

### DIFF
--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerMethodWriter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerMethodWriter.java
@@ -100,6 +100,13 @@ class ControllerMethodWriter {
   }
 
   private void writeContextReturn() {
+
+    if (instrumentContext) {
+      writer
+          .append("      if (ctx.resultInputStream() != null || ctx.res().isCommitted()) return;")
+          .eol();
+    }
+
     // Support for CompletableFuture's.
     final UType type = UType.parse(method.returnType());
     if ("java.util.concurrent.CompletableFuture".equals(type.mainType())) {


### PR DESCRIPTION
Now when using ServerContext, we can write to the context response from an aspect and the controller method's result serialization can be skipped.


Fixes https://github.com/avaje/avaje-http/issues/210 from a certain point of view.