### PR TITLE
Change how Generated Clients are registered.

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/InstrumentServerContext.java
+++ b/http-api/src/main/java/io/avaje/http/api/InstrumentServerContext.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
  * @Get
  * @InstrumentServerContext
  * void helloWorld(long id) {
- *  Server resolver.currentRequest()
+ *  Context = resolver.currentRequest()
  *   ...
  * }
  *

--- a/http-api/src/main/java/io/avaje/http/api/spi/MetaData.java
+++ b/http-api/src/main/java/io/avaje/http/api/spi/MetaData.java
@@ -1,0 +1,18 @@
+package io.avaje.http.api.spi;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.*;
+
+/**
+ * For internal use, holds metadata on generated client interfaces for use by code generation (Java
+ * annotation processing).
+ */
+@Target(TYPE)
+@Retention(CLASS)
+public @interface MetaData {
+
+  /** The generated HttpClient interfaces. */
+  Class<?>[] value();
+}

--- a/http-api/src/main/java/module-info.java
+++ b/http-api/src/main/java/module-info.java
@@ -2,4 +2,5 @@ module io.avaje.http.api {
 
 	exports io.avaje.http.api;
 	exports io.avaje.http.api.context;
+	exports io.avaje.http.api.spi;
 }

--- a/http-client/src/main/java/io/avaje/http/client/DHttpApi.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpApi.java
@@ -1,6 +1,7 @@
 package io.avaje.http.client;
 
 import io.avaje.applog.AppLog;
+import io.avaje.http.client.HttpClient.GeneratedComponent;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,20 +20,21 @@ final class DHttpApi {
 
   private final Map<Class<?>, HttpApiProvider<?>> providerMap = new HashMap<>();
 
-  DHttpApi() {
+  private DHttpApi() {
     init();
   }
 
   @SuppressWarnings("rawtypes")
   void init() {
-    for (HttpApiProvider apiProvider : ServiceLoader.load(HttpApiProvider.class)) {
-      addProvider(apiProvider);
+    for (final HttpApiProvider apiProvider : ServiceLoader.load(HttpApiProvider.class)) {
+      providerMap.put(apiProvider.type(), apiProvider);
     }
-    log.log(DEBUG, "providers for {0}", providerMap.keySet());
-  }
 
-  void addProvider(HttpApiProvider<?> apiProvider) {
-    providerMap.put(apiProvider.type(), apiProvider);
+    for (final GeneratedComponent apiProvider : ServiceLoader.load(GeneratedComponent.class)) {
+      apiProvider.register(providerMap);
+    }
+
+    log.log(DEBUG, "providers for {0}", providerMap.keySet());
   }
 
   @SuppressWarnings("unchecked")

--- a/http-client/src/main/java/io/avaje/http/client/DHttpApi.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpApi.java
@@ -20,7 +20,7 @@ final class DHttpApi {
 
   private final Map<Class<?>, HttpApiProvider<?>> providerMap = new HashMap<>();
 
-  private DHttpApi() {
+  DHttpApi() {
     init();
   }
 

--- a/http-client/src/main/java/io/avaje/http/client/DHttpApi.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpApi.java
@@ -27,7 +27,7 @@ final class DHttpApi {
   @SuppressWarnings("rawtypes")
   void init() {
     for (final HttpApiProvider apiProvider : ServiceLoader.load(HttpApiProvider.class)) {
-      providerMap.put(apiProvider.type(), apiProvider);
+      addProvider(apiProvider);
     }
 
     for (final GeneratedComponent apiProvider : ServiceLoader.load(GeneratedComponent.class)) {
@@ -35,6 +35,10 @@ final class DHttpApi {
     }
 
     log.log(DEBUG, "providers for {0}", providerMap.keySet());
+  }
+
+  void addProvider(HttpApiProvider<?> apiProvider) {
+    providerMap.put(apiProvider.type(), apiProvider);
   }
 
   @SuppressWarnings("unchecked")

--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -246,7 +246,7 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
   }
 
   @Override
-public byte[] decodeContent(HttpResponse<byte[]> httpResponse) {
+  public byte[] decodeContent(HttpResponse<byte[]> httpResponse) {
     final String encoding = getContentEncoding(httpResponse);
     return encoding == null ? httpResponse.body() : decodeContent(encoding, httpResponse.body());
   }

--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -58,16 +58,27 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
     if (!clientInterface.isInterface()) {
       throw new IllegalArgumentException("API declarations must be interfaces.");
     }
-    HttpApiProvider<T> apiProvider = DHttpApi.get(clientInterface);
+    final HttpApiProvider<T> apiProvider = DHttpApi.get(clientInterface);
     if (apiProvider != null) {
       return apiProvider.provide(this);
     }
     try {
-      Class<?> implementationClass = implementationClass(clientInterface);
-      Constructor<?> constructor = implementationClass.getConstructor(HttpClientContext.class);
+      final Class<?> implementationClass = implementationClass(clientInterface);
+      final Constructor<?> constructor = implementationClass.getConstructor(HttpClient.class);
       return (T) constructor.newInstance(this);
-    } catch (Exception e) {
-      String cn = implementationClassName(clientInterface, "HttpClient");
+    } catch (final Exception e) {
+      return constructReflectively(clientInterface);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T constructReflectively(Class<T> clientInterface) {
+    try {
+      final Class<?> implementationClass = implementationClass(clientInterface);
+      final Constructor<?> constructor = implementationClass.getConstructor(HttpClientContext.class);
+      return (T) constructor.newInstance(this);
+    } catch (final Exception e) {
+      final String cn = implementationClassName(clientInterface, "HttpClient");
       throw new IllegalStateException("Failed to create http client service " + cn, e);
     }
   }
@@ -75,15 +86,15 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
   private Class<?> implementationClass(Class<?> clientInterface) throws ClassNotFoundException {
     try {
       return Class.forName(implementationClassName(clientInterface, "HttpClient"));
-    } catch (ClassNotFoundException e) {
+    } catch (final ClassNotFoundException e) {
       // try the older generated client suffix
       return Class.forName(implementationClassName(clientInterface, "$HttpClient"));
     }
   }
 
   private <T> String implementationClassName(Class<T> clientInterface, String suffix) {
-    String packageName = clientInterface.getPackageName();
-    String simpleName = clientInterface.getSimpleName();
+    final String packageName = clientInterface.getPackageName();
+    final String simpleName = clientInterface.getSimpleName();
     return packageName + ".httpclient." + simpleName + suffix;
   }
 
@@ -202,7 +213,7 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
     if (body instanceof String) {
       return new BodyContent(contentType, ((String) body).getBytes(StandardCharsets.UTF_8));
     }
-    String type = (body == null) ? "null" : body.getClass().toString();
+    final String type = (body == null) ? "null" : body.getClass().toString();
     throw new IllegalStateException("Unable to translate response body to bytes? Maybe use HttpResponse directly instead?  Response body type: " + type);
   }
 
@@ -212,7 +223,7 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
     if (body != null && body.length > 0) {
       metricResBytes.add(body.length);
     }
-    byte[] bodyBytes = decodeContent(httpResponse);
+    final byte[] bodyBytes = decodeContent(httpResponse);
     final String contentType = getContentType(httpResponse);
     return new BodyContent(contentType, bodyBytes);
   }
@@ -227,21 +238,22 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
 
   @Override
   public byte[] decodeContent(String encoding, byte[] body) {
-    if (encoding.equals("gzip")) {
+    if ("gzip".equals(encoding)) {
       return GzipUtil.gzipDecode(body);
     }
     // todo: register decoders with context and use them
     return body;
   }
 
-  public byte[] decodeContent(HttpResponse<byte[]> httpResponse) {
-    String encoding = getContentEncoding(httpResponse);
+  @Override
+public byte[] decodeContent(HttpResponse<byte[]> httpResponse) {
+    final String encoding = getContentEncoding(httpResponse);
     return encoding == null ? httpResponse.body() : decodeContent(encoding, httpResponse.body());
   }
 
   String firstHeader(HttpHeaders headers, String... names) {
     final Map<String, List<String>> map = headers.map();
-    for (String key : names) {
+    for (final String key : names) {
       final List<String> values = map.get(key);
       if (values != null && !values.isEmpty()) {
         return values.get(0);
@@ -253,9 +265,9 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
   <T> HttpResponse<T> send(HttpRequest.Builder requestBuilder, HttpResponse.BodyHandler<T> bodyHandler) {
     try {
       return httpClient.send(requestBuilder.build(), bodyHandler);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new HttpException(499, e);
-    } catch (InterruptedException e) {
+    } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new HttpException(499, e);
     }

--- a/http-client/src/main/java/io/avaje/http/client/HttpApiProvider.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpApiProvider.java
@@ -1,20 +1,20 @@
 package io.avaje.http.client;
 
+import java.util.Map;
+
 /**
  * Provides http client implementations for an interface.
  *
  * @param <T> The interface type
  */
+@FunctionalInterface
 public interface HttpApiProvider<T> {
 
-  /**
-   * Return the interface type this API implements.
-   */
-  Class<T> type();
+  /** Return the interface type this API implements. */
+  default Class<T> type() {
+    throw new UnsupportedOperationException();
+  }
 
-  /**
-   * Return the provided implementation of the API.
-   */
+  /** Return the provided implementation of the API. */
   T provide(HttpClient client);
-
 }

--- a/http-client/src/main/java/io/avaje/http/client/HttpClient.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClient.java
@@ -1,14 +1,16 @@
 package io.avaje.http.client;
 
-import io.avaje.inject.BeanScope;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLParameters;
 import java.net.Authenticator;
 import java.net.CookieHandler;
 import java.net.ProxySelector;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.Executor;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+import io.avaje.inject.BeanScope;
 
 /**
  * The HTTP client context that we use to build and process requests.
@@ -355,5 +357,12 @@ public interface HttpClient {
    */
   interface Metrics extends HttpClientContext.Metrics {
 
+  }
+
+  /** Components register Generated Client interface Providers */
+  @FunctionalInterface
+  interface GeneratedComponent {
+
+    void register(Map<Class<?>, HttpApiProvider<?>> providerMap);
   }
 }

--- a/http-client/src/main/java/module-info.java
+++ b/http-client/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module io.avaje.http.client {
 
   uses io.avaje.http.client.HttpApiProvider;
+  uses io.avaje.http.client.HttpClient.GeneratedComponent;
 
   requires transitive java.net.http;
   requires transitive io.avaje.applog;

--- a/http-generator-client/pom.xml
+++ b/http-generator-client/pom.xml
@@ -21,6 +21,19 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-http-client</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-http-api</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -34,6 +47,14 @@
           <target>11</target>
           <!-- Turn off annotation processing for building -->
           <compilerArgument>-proc:none</compilerArgument>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
         </configuration>
       </plugin>
     </plugins>

--- a/http-generator-client/pom.xml
+++ b/http-generator-client/pom.xml
@@ -11,10 +11,16 @@
 
   <properties>
     <java.version>11</java.version>
+    <avaje.prisms.version>1.9</avaje.prisms.version>
   </properties>
-
   <dependencies>
-
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-prisms</artifactId>
+      <version>${avaje.prisms.version}</version>
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-generator-core</artifactId>
@@ -30,8 +36,9 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <scope>test</scope>
       <version>${project.version}</version>
+      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>
@@ -41,12 +48,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
-          <!-- Turn off annotation processing for building -->
-          <compilerArgument>-proc:none</compilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.avaje</groupId>
+              <artifactId>avaje-prisms</artifactId>
+              <version>${avaje.prisms.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
@@ -15,7 +15,6 @@ import java.util.List;
 class ClientWriter extends BaseControllerWriter {
 
   private static final String HTTP_CLIENT = "io.avaje.http.client.HttpClient";
-  private static final String HTTP_API_PROVIDER = "io.avaje.http.client.HttpApiProvider";
 
   private static final String AT_GENERATED = "@Generated(\"avaje-http-client-generator\")";
   private static final String SUFFIX = "HttpClient";
@@ -26,7 +25,6 @@ class ClientWriter extends BaseControllerWriter {
   ClientWriter(ControllerReader reader, boolean useJsonB) throws IOException {
     super(reader, SUFFIX);
     reader.addImportType(HTTP_CLIENT);
-    reader.addImportType(HTTP_API_PROVIDER);
     this.useJsonb = useJsonB;
     readMethods();
     if (useJsonB) reader.addImportType("io.avaje.jsonb.Types");
@@ -39,7 +37,7 @@ class ClientWriter extends BaseControllerWriter {
   }
 
   private void readMethods() {
-    for (MethodReader method : reader.methods()) {
+    for (final MethodReader method : reader.methods()) {
       if (method.isWebMethod()) {
         final var methodWriter = new ClientMethodWriter(method, writer, useJsonb);
         methodWriter.addImportTypes(reader);
@@ -53,26 +51,12 @@ class ClientWriter extends BaseControllerWriter {
     writeImports();
     writeClassStart();
     writeMethods();
-    writeProvider();
     writeClassEnd();
     return fullName;
   }
 
-  private void writeProvider() {
-    writer.append("  public static class Provider implements HttpApiProvider<%s> {", shortName).eol();
-    writer.append("    @Override").eol();
-    writer.append("    public Class<%s> type() {", shortName).eol();
-    writer.append("      return %s.class;", shortName).eol();
-    writer.append("    }").eol();
-    writer.append("    @Override").eol();
-    writer.append("    public %s provide(HttpClient client) {", shortName).eol();
-    writer.append("      return new %s%s(client);", shortName, SUFFIX).eol();
-    writer.append("    }").eol();
-    writer.append("  }").eol();
-  }
-
   private void writeMethods() {
-    for (ClientMethodWriter methodWriter : methodList) {
+    for (final ClientMethodWriter methodWriter : methodList) {
       methodWriter.write();
     }
   }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentMetaData.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentMetaData.java
@@ -1,0 +1,71 @@
+package io.avaje.http.generator.client;
+
+import java.util.*;
+
+final class ComponentMetaData {
+
+  private final List<String> generatedClients = new ArrayList<>();
+  private String fullName;
+
+  @Override
+  public String toString() {
+    return generatedClients.toString();
+  }
+
+  /** Ensure the component name has been initialised. */
+  void initialiseFullName() {
+    fullName();
+  }
+
+  boolean contains(String type) {
+    return generatedClients.contains(type);
+  }
+
+  void add(String type) {
+    generatedClients.add(type);
+  }
+
+  void setFullName(String fullName) {
+    this.fullName = fullName;
+  }
+
+  String fullName() {
+    if (fullName == null) {
+
+      String topPackage = TopPackage.of(generatedClients);
+      if (!topPackage.endsWith(".httpclient")) {
+        topPackage += ".httpclient";
+      }
+      fullName = topPackage + ".GeneratedHttpComponent";
+    }
+    return fullName;
+  }
+
+  String packageName() {
+    return TopPackage.packageOf(fullName());
+  }
+
+  List<String> all() {
+    return generatedClients;
+  }
+
+  /** Return the package imports for the JsonAdapters and related types. */
+  Collection<String> allImports() {
+    final Set<String> packageImports = new TreeSet<>(generatedClients);
+    generatedClients.stream()
+        .map(s -> removeLast(removeLast(s, ".httpclient"), "HttpClient"))
+        .forEach(packageImports::add);
+
+    return packageImports;
+  }
+
+  public static String removeLast(String s, String search) {
+    final int pos = s.lastIndexOf(search);
+
+    if (pos > -1) {
+      return s.substring(0, pos) + s.substring(pos + search.length());
+    }
+
+    return s;
+  }
+}

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentReader.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentReader.java
@@ -1,0 +1,91 @@
+package io.avaje.http.generator.client;
+import static io.avaje.http.generator.core.ProcessingContext.filer;
+import static io.avaje.http.generator.core.ProcessingContext.logDebug;
+import static io.avaje.http.generator.core.ProcessingContext.logWarn;
+import static io.avaje.http.generator.core.ProcessingContext.typeElement;
+
+import java.io.FileNotFoundException;
+import java.io.LineNumberReader;
+import java.io.Reader;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.processing.FilerException;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+import io.avaje.http.generator.core.Constants;
+import io.avaje.prism.GeneratePrism;
+
+@GeneratePrism(io.avaje.http.api.spi.MetaData.class)
+final class ComponentReader {
+
+  private final ComponentMetaData componentMetaData;
+
+  ComponentReader(ComponentMetaData metaData) {
+    this.componentMetaData = metaData;
+  }
+
+  void read() {
+    final String componentFullName = loadMetaInfServices();
+    if (componentFullName != null) {
+      final TypeElement moduleType = typeElement(componentFullName);
+      if (moduleType != null) {
+        componentMetaData.setFullName(componentFullName);
+        readMetaData(moduleType);
+      }
+    }
+  }
+
+  /** Read the existing JsonAdapters from the MetaData annotation of the generated component. */
+  private void readMetaData(TypeElement moduleType) {
+    for (final AnnotationMirror annotationMirror : moduleType.getAnnotationMirrors()) {
+      MetaDataPrism.getOptional(annotationMirror).map(MetaDataPrism::value).stream()
+          .flatMap(List::stream)
+          .map(TypeMirror::toString)
+          .forEach(componentMetaData::add);
+    }
+  }
+
+  private String loadMetaInfServices() {
+    final List<String> lines = loadMetaInf();
+    return lines.isEmpty() ? null : lines.get(0);
+  }
+
+  private List<String> loadMetaInf() {
+    try {
+      final FileObject fileObject = filer()
+        .getResource(StandardLocation.CLASS_OUTPUT, "", Constants.META_INF_COMPONENT);
+
+      if (fileObject != null) {
+        final List<String> lines = new ArrayList<>();
+        final Reader reader = fileObject.openReader(true);
+        final LineNumberReader lineReader = new LineNumberReader(reader);
+        String line;
+        while ((line = lineReader.readLine()) != null) {
+          line = line.trim();
+          if (!line.isEmpty()) {
+            lines.add(line);
+          }
+        }
+        return lines;
+      }
+
+    } catch (FileNotFoundException | NoSuchFileException e) {
+      // logDebug("no services file yet");
+
+    } catch (final FilerException e) {
+      logDebug("FilerException reading services file");
+
+    } catch (final Exception e) {
+      e.printStackTrace();
+      logWarn("Error reading services file: " + e.getMessage());
+    }
+    return Collections.emptyList();
+  }
+}

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/SimpleComponentWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/SimpleComponentWriter.java
@@ -1,0 +1,124 @@
+package io.avaje.http.generator.client;
+
+import static io.avaje.http.generator.core.ProcessingContext.createMetaInfWriter;
+import static io.avaje.http.generator.core.ProcessingContext.createWriter;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.tools.FileObject;
+import javax.tools.JavaFileObject;
+
+import io.avaje.http.generator.core.Append;
+import io.avaje.http.generator.core.Util;
+
+final class SimpleComponentWriter {
+
+  private static final String AT_GENERATED = "@Generated(\"avaje-client-generator\")";
+
+  private final Set<String> generatedClients;
+  private final Set<String> importTypes = new TreeSet<>();
+  private Append writer;
+  private final JavaFileObject fileObject;
+  private final String fullName;
+
+  SimpleComponentWriter(Set<String> generatedClients) throws IOException {
+    this.generatedClients = generatedClients;
+    this.fullName = fullName();
+    fileObject = createWriter(fullName());
+  }
+
+  String fullName() {
+    String topPackage = TopPackage.of(generatedClients);
+    if (!topPackage.endsWith(".httpclient")) {
+      topPackage += ".httpclient";
+    }
+    return topPackage + ".GeneratedHttpComponent";
+  }
+
+  void write() throws IOException {
+    writer = new Append(fileObject.openWriter());
+    writePackage();
+    writeImports();
+    writeClassStart();
+    writeRegister();
+    writeClassEnd();
+    writer.close();
+    writeMetaInf();
+  }
+
+  void writeMetaInf() throws IOException {
+    final FileObject fileObject =
+        createMetaInfWriter("META-INF/services/io.avaje.http.client.HttpClient$GeneratedComponent");
+    if (fileObject != null) {
+      try (var fileWriter = fileObject.openWriter()) {
+        fileWriter.write(fullName);
+      }
+    }
+  }
+
+  private void writeRegister() {
+    writer.append("  @Override").eol();
+    writer.append("  public void register(Map<Class<?>, HttpApiProvider<?>> providerMap) {").eol();
+
+    for (final String clientFullName : generatedClients) {
+
+      final String clientShortName = Util.shortName(clientFullName);
+      final var clientInterface = removeLast(clientShortName, "HttpClient");
+      writer
+          .append("    providerMap.put(%s.class, %s::new);", clientInterface, clientShortName)
+          .eol();
+    }
+    writer.append("  }").eol().eol();
+  }
+
+  private void writeClassEnd() {
+    writer.append("}").eol();
+  }
+
+  private void writeClassStart() {
+    final String shortName = Util.shortName(fullName);
+    writer.append(AT_GENERATED).eol();
+    writer
+        .append("public class %s implements HttpClient.GeneratedComponent {", shortName)
+        .eol()
+        .eol();
+  }
+
+  private void writeImports() {
+    importTypes.add("io.avaje.http.client.HttpClient");
+    importTypes.add("io.avaje.http.client.HttpApiProvider");
+    importTypes.add("java.util.Map");
+    importTypes.add("io.avaje.http.api.Generated");
+
+    importTypes.addAll(generatedClients);
+    generatedClients.stream()
+        .map(s -> removeLast(removeLast(s, ".httpclient"), "HttpClient"))
+        .forEach(importTypes::add);
+
+    for (final String importType : importTypes) {
+      writer.append("import %s;", importType).eol();
+      writer.append("import %s;", importType).eol();
+    }
+    writer.eol();
+  }
+
+  public static String removeLast(String s, String search) {
+    final int pos = s.lastIndexOf(search);
+
+    if (pos > -1) {
+      return s.substring(0, pos) + s.substring(pos + search.length());
+    }
+
+    return s;
+  }
+
+  private void writePackage() {
+    final String packageName = TopPackage.packageOf(fullName);
+    if (packageName != null && !packageName.isEmpty()) {
+      writer.append("package %s;", packageName).eol().eol();
+    }
+  }
+}

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/TopPackage.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/TopPackage.java
@@ -1,0 +1,48 @@
+package io.avaje.http.generator.client;
+
+import java.util.Collection;
+
+final class TopPackage {
+
+  private String topPackage;
+
+  static String of(Collection<String> values) {
+    return new TopPackage(values).value();
+  }
+
+  private String value() {
+    return topPackage;
+  }
+
+  private TopPackage(Collection<String> values) {
+    for (final String pkg : values) {
+      topPackage = commonParent(topPackage, pkg);
+    }
+  }
+
+  /** Return the common parent package. */
+  static String commonParent(String currentTop, String aPackage) {
+    if (aPackage == null) return currentTop;
+    if (currentTop == null) return packageOf(aPackage);
+    if (aPackage.startsWith(currentTop)) {
+      return currentTop;
+    }
+    int next;
+    do {
+      next = currentTop.lastIndexOf('.');
+      if (next > -1) {
+        currentTop = currentTop.substring(0, next);
+        if (aPackage.startsWith(currentTop)) {
+          return currentTop;
+        }
+      }
+    } while (next > -1);
+
+    return currentTop;
+  }
+
+  static String packageOf(String cls) {
+    final int pos = cls.lastIndexOf('.');
+    return (pos == -1) ? "" : cls.substring(0, pos);
+  }
+}

--- a/http-generator-client/src/main/java/module-info.java
+++ b/http-generator-client/src/main/java/module-info.java
@@ -6,6 +6,8 @@ module io.avaje.http.client.generator {
   requires java.sql;
 
   // SHADED: All content after this line will be removed at package time
-  requires transitive io.avaje.http.generator.core;
+  requires io.avaje.http.generator.core;
+  requires static io.avaje.http.api;
+  requires static io.avaje.prism;
 
 }

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/ClientProcessorTest.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/ClientProcessorTest.java
@@ -1,0 +1,68 @@
+package io.avaje.http.generator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ClientProcessorTest {
+
+  @AfterEach
+  void deleteGeneratedFiles() throws IOException {
+    try {
+      Paths.get("io.avaje.http.client.HttpClient$GeneratedComponent")
+          .toAbsolutePath()
+          .toFile()
+          .delete();
+      Files.walk(Paths.get("io").toAbsolutePath())
+          .sorted(Comparator.reverseOrder())
+          .map(Path::toFile)
+          .forEach(File::delete);
+    } catch (final Exception e) {
+    }
+  }
+
+  @Test
+  void testGeneration() throws Exception {
+    final Iterable<JavaFileObject> files = getSourceFiles("src/test/java/");
+
+    final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+    final CompilationTask task =
+        compiler.getTask(
+            new PrintWriter(System.out), null, null, Arrays.asList("--release=11"), null, files);
+    task.setProcessors(Arrays.asList(new ClientProcessor()));
+
+    assertThat(task.call()).isTrue();
+  }
+
+  private Iterable<JavaFileObject> getSourceFiles(String source) throws Exception {
+    final var compiler = ToolProvider.getSystemJavaCompiler();
+    final var files = compiler.getStandardFileManager(null, null, null);
+
+    files.setLocation(StandardLocation.SOURCE_PATH, List.of(new File(source)));
+
+    final Set<Kind> fileKinds = Collections.singleton(Kind.SOURCE);
+    return files.list(StandardLocation.SOURCE_PATH, "", fileKinds, true);
+  }
+}

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/ApiClient.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/ApiClient.java
@@ -1,0 +1,12 @@
+package io.avaje.http.generator.client.clients;
+
+import io.avaje.http.api.Client;
+import io.avaje.http.api.Get;
+import io.avaje.http.api.Header;
+
+@Client
+public interface ApiClient {
+
+  @Get("/inputstream")
+  String apiCall(@Header("Accept") String accept);
+}

--- a/http-generator-core/pom.xml
+++ b/http-generator-core/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>avaje-http-generator-core</artifactId>
 
   <properties>
-    <avaje.prisms.version>1.8</avaje.prisms.version>
+    <avaje.prisms.version>1.9</avaje.prisms.version>
   </properties>
   <dependencies>
     <dependency>

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/Constants.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/Constants.java
@@ -18,5 +18,7 @@ public class Constants {
 
   static final String IMPORT_HTTP_API = "io.avaje.http.api.*";
   static final String VALIDATOR = "io.avaje.http.api.Validator";
+  public static final String META_INF_COMPONENT = "META-INF/services/io.avaje.http.client.HttpClient$GeneratedComponent";
+
 
 }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -108,6 +108,10 @@ public class ProcessingContext {
     return CTX.get().useComponent;
   }
 
+  public static void logError(String msg, Object... args) {
+    CTX.get().messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args));
+  }
+
   public static void logError(Element e, String msg, Object... args) {
     CTX.get().messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
   }
@@ -120,6 +124,10 @@ public class ProcessingContext {
   /** Create a file writer for the META-INF services file. */
   public static FileObject createMetaInfWriter(String target) throws IOException {
     return CTX.get().filer.createResource(StandardLocation.CLASS_OUTPUT, "", target);
+  }
+
+  public static JavaFileObject createWriter(String cls) throws IOException {
+    return CTX.get().filer.createSourceFile(cls);
   }
 
   public static String docComment(Element param) {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -116,6 +116,13 @@ public class ProcessingContext {
     CTX.get().messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
   }
 
+  public static void logWarn(String msg, Object... args) {
+    CTX.get().messager.printMessage(Diagnostic.Kind.WARNING, String.format(msg, args));
+  }
+
+  public static void logDebug(String msg, Object... args) {
+    CTX.get().messager.printMessage(Diagnostic.Kind.NOTE, String.format(msg, args));
+  }
   /** Create a file writer for the given class name. */
   public static JavaFileObject createWriter(String cls, Element origin) throws IOException {
     return CTX.get().filer.createSourceFile(cls, origin);
@@ -175,5 +182,9 @@ public class ProcessingContext {
 
   public static boolean instrumentAllWebMethods() {
     return CTX.get().instrumentAllMethods;
+  }
+
+  public static Filer filer() {
+    return CTX.get().filer;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>3.9</version>
+    <version>3.10</version>
   </parent>
 
   <groupId>io.avaje</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
     <swagger.version>2.2.8</swagger.version>
     <jackson.version>2.14.2</jackson.version>
+    <avaje.prisms.version>1.9</avaje.prisms.version>
     <module-info.shade>${project.build.directory}${file.separator}module-info.shade</module-info.shade>
   </properties>
 

--- a/tests/test-client/src/test/java/example/github/GithubTest.java
+++ b/tests/test-client/src/test/java/example/github/GithubTest.java
@@ -14,6 +14,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class GithubTest {
 
+  @Test
+  void test_create() {
+    final HttpClient client = HttpClient.builder().baseUrl("https://api.github.com").build();
+
+    final Simple simple = client.create(Simple.class);
+    assertThat(simple).isNotNull();
+  }
+
   @Disabled
   @Test
   void test_with_jackson() {


### PR DESCRIPTION
- Make `HttpApiProvider` a functional interface
- now generates a `GeneratedComponent` class that adds `HttpApiProvider`s to ```DHttpApi```
- no longer generates a provider nested class. (the generated client constructor is used as an HttpApiProvider)
- client processor test for easier debugging of issues 
- can reflectively retrieve implementations using `HttpClient` as well as `HttpClientContext`. 

fixes #217 

this is how the generated component looks

```java
@Generated("avaje-client-generator")
public class GeneratedHttpComponent implements HttpClient.GeneratedComponent {
  @Override
  public void register(Map<Class<?>, HttpApiProvider<?>> providerMap) {
    providerMap.put(ApiClient.class, ApiClientHttpClient::new);
  }
}
```