### PR TITLE
[HttpClient] Remove deprecated method withHandler() migrate to handler()

### DIFF
--- a/http-client-gson-adapter/src/main/java/io/avaje/http/client/gson/GsonBodyAdapter.java
+++ b/http-client-gson-adapter/src/main/java/io/avaje/http/client/gson/GsonBodyAdapter.java
@@ -21,7 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  *
  * <pre>{@code
  *
- *   HttpClientContext.builder()
+ *   HttpClient.builder()
  *       .baseUrl(baseUrl)
  *       .requestListener(new RequestLogger())
  *       //.bodyAdapter(new JacksonBodyAdapter(new ObjectMapper()))

--- a/http-client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
@@ -225,14 +225,6 @@ public interface HttpAsyncResponse {
   <E> CompletableFuture<HttpResponse<E>> handler(HttpResponse.BodyHandler<E> bodyHandler);
 
   /**
-   * Deprecated - migrate to handler().
-   */
-  @Deprecated
-  default <E> CompletableFuture<HttpResponse<E>> withHandler(HttpResponse.BodyHandler<E> bodyHandler) {
-    return handler(bodyHandler);
-  }
-
-  /**
    * Process converting the response body to the given type.
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains

--- a/http-client/src/main/java/io/avaje/http/client/HttpCallResponse.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpCallResponse.java
@@ -119,14 +119,6 @@ public interface HttpCallResponse {
   <E> HttpCall<HttpResponse<E>> handler(HttpResponse.BodyHandler<E> bodyHandler);
 
   /**
-   * Deprecated - migrate to handler().
-   */
-  @Deprecated
-  default <E> HttpCall<HttpResponse<E>> withHandler(HttpResponse.BodyHandler<E> bodyHandler) {
-    return handler(bodyHandler);
-  }
-
-  /**
    * A bean response to execute async or sync.
    * <p>
    * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains

--- a/http-client/src/main/java/io/avaje/http/client/HttpClient.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClient.java
@@ -73,19 +73,6 @@ public interface HttpClient {
   UrlBuilder url();
 
   /**
-   * Deprecated - migrate to {@link #bodyAdapter()}.
-   * <p>
-   * Return the body adapter used by the client context.
-   * <p>
-   * This is the body adapter used to convert request and response
-   * bodies to java types. For example using Jackson with JSON payloads.
-   */
-  @Deprecated
-  default BodyAdapter converters() {
-    return bodyAdapter();
-  }
-
-  /**
    * Return the BodyAdapter that this client is using.
    */
   BodyAdapter bodyAdapter();
@@ -355,8 +342,37 @@ public interface HttpClient {
   /**
    * Statistic metrics collected to provide an overview of activity of this client.
    */
-  interface Metrics extends HttpClientContext.Metrics {
+  interface Metrics {
 
+    /**
+     * Return the total number of responses.
+     */
+    long totalCount();
+
+    /**
+     * Return the total number of error responses (status code >= 300).
+     */
+    long errorCount();
+
+    /**
+     * Return the total response bytes (excludes streaming responses).
+     */
+    long responseBytes();
+
+    /**
+     * Return the total response time in microseconds.
+     */
+    long totalMicros();
+
+    /**
+     * Return the max response time in microseconds (since the last reset).
+     */
+    long maxMicros();
+
+    /**
+     * Return the average response time in microseconds.
+     */
+    long avgMicros();
   }
 
   /** Components register Generated Client interface Providers */

--- a/http-client/src/main/java/io/avaje/http/client/HttpClientResponse.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClientResponse.java
@@ -307,12 +307,4 @@ public interface HttpClientResponse {
    */
   <T> HttpResponse<T> handler(HttpResponse.BodyHandler<T> responseHandler);
 
-  /**
-   * Deprecated - migrate to handler().
-   */
-  @Deprecated
-  default <T> HttpResponse<T> withHandler(HttpResponse.BodyHandler<T> responseHandler) {
-    return handler(responseHandler);
-  }
-
 }


### PR DESCRIPTION
Migrate from withHandler(HttpResponse.BodyHandler<E> bodyHandler) to handler(HttpResponse.BodyHandler<E> bodyHandler)