### PR TITLE
Extendable Clients

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,3 @@
+ignoreFiles="""
+tests/**
+"""

--- a/http-api/src/main/java/io/avaje/http/api/Client.java
+++ b/http-api/src/main/java/io/avaje/http/api/Client.java
@@ -11,31 +11,29 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Marker annotation for client.
  *
  * <pre>{@code
+ * @Client
+ * interface CustomerApi {
+ *   ...
+ *   @Get("/{id}")
+ *   Customer getById(long id);
  *
- *   @Client
- *   interface CustomerApi {
- *     ...
- *     @Get("/{id}")
- *     Customer getById(long id);
- *
- *     @Post
- *     long save(Customer customer);
- *   }
+ *   @Post
+ *   long save(Customer customer);
+ * }
  *
  * }</pre>
  *
  * <h3>Client.Import</h3>
- * <p>
- * When the client interface already exists in another module we
- * use <code>Client.Import</code> to generate the client.
- * <p>
- * Specify the <code>@Client.Import</code> on the package or class
- * to refer to the client interface we want to generate.
+ *
+ * <p>When the client interface already exists in another module we use <code>Client.Import</code>
+ * to generate the client.
+ *
+ * <p>Specify the <code>@Client.Import</code> on the package or class to refer to the client
+ * interface we want to generate.
  *
  * <pre>{@code
- *
- *   @Client.Import(types = OtherApi.class)
- *   package org.example;
+ * @Client.Import(types = OtherApi.class)
+ * package org.example;
  *
  * }</pre>
  */
@@ -43,8 +41,24 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(value = RUNTIME)
 public @interface Client {
 
+  /**
+   * Flag to set whether to generate a Client Implementation. Set false if the interface exists merely to be extended by
+   * other client interfaces
+   */
+  boolean generate() default true;
+
+  /**
+   * Specify <code>@Client.Import</code> on a package or class to refer to the client interface we
+   * want to generate.
+   *
+   * <pre>{@code
+   * @Client.Import(types = OtherApi.class)
+   * package org.example;
+   *
+   * }</pre>
+   */
   @Target(value = {TYPE, PACKAGE})
-  @Retention(value = RUNTIME)
+  @Retention(RUNTIME)
   @interface Import {
 
     /**

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -65,7 +65,9 @@ public class ClientProcessor extends AbstractProcessor {
     readModule();
     for (final Element controller :
         round.getElementsAnnotatedWith(typeElement(ClientPrism.PRISM_TYPE))) {
-      writeClient(controller);
+      if (ClientPrism.getInstanceOn(controller).generate()) {
+        writeClient(controller);
+      }
     }
     for (final var importedElement : round.getElementsAnnotatedWith(typeElement(ImportPrism.PRISM_TYPE))) {
       writeForImported(importedElement);

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/ExampleClient.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/ExampleClient.java
@@ -1,0 +1,6 @@
+package io.avaje.http.generator.client.clients;
+
+import io.avaje.http.api.Client;
+
+@Client
+public interface ExampleClient extends UserClient {}

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/ExampleClient2.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/ExampleClient2.java
@@ -4,7 +4,7 @@ import io.avaje.http.api.Client;
 import io.avaje.http.api.Patch;
 
 @Client
-public interface ExampleClient extends UserClient {
+public interface ExampleClient2 extends ExampleClient {
   @Patch
-  void patchy();
+  void patchy2();
 }

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/UserClient.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/UserClient.java
@@ -1,0 +1,16 @@
+package io.avaje.http.generator.client.clients;
+
+import io.avaje.http.api.BodyString;
+import io.avaje.http.api.Client;
+import io.avaje.http.api.Get;
+import io.avaje.http.api.Post;
+
+@Client(generate = false)
+public interface UserClient {
+
+  @Post("/users")
+  String createUser(@BodyString String body);
+
+  @Get("/users/{userId}")
+  String getUserById(String userId);
+}


### PR DESCRIPTION
Now will generate the extended interface's http method implementation.

- adds a parameter to `@Client` that will disable generation is desired
- modify generation to read super client interface methods