### PR TITLE
Fix Jsonb Controller for modular projects without compiler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ public class WidgetController$Route implements HttpService {
     int id = asInt(pathParams.first("id").get());
     var result = controller.getById(id);
     res.headers().contentType(io.helidon.common.http.HttpMediaType.APPLICATION_JSON);
-    widgetJsonType.toJson(result, res.outputStream());
+    widgetJsonType.toJson(result, JsonOutput.of(res));
   }
 
   private void _getAll(ServerRequest req, ServerResponse res) {

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ public class WidgetController$Route implements WebRoutes {
     });
 
   }
-
 }
 ```
 
@@ -190,7 +189,6 @@ public class WidgetController$Route implements Service {
   private void _getAll(ServerRequest req, ServerResponse res) {
     res.send(controller.getAll());
   }
-
 }
 ```
 
@@ -224,7 +222,6 @@ public class WidgetController$Route implements HttpService {
     var result = controller.getAll();
     res.send(result);
   }
-
 }
 ```
 
@@ -264,7 +261,6 @@ public class WidgetController$Route implements WebRoutes {
     });
 
   }
-
 }
 ```
 
@@ -303,9 +299,8 @@ public class WidgetController$Route implements HttpService {
   private void _getAll(ServerRequest req, ServerResponse res) {
     var pathParams = req.path().pathParameters();
     var result = controller.getAll();
-    res.headers().contentType(io.helidon.common.http.HttpMediaType.APPLICATION_JSON);
-    listWidgetJsonType.toJson(result, res.outputStream());
+    res.headers().contentType(HttpMediaType.APPLICATION_JSON);
+    listWidgetJsonType.toJson(result, JsonOutput.of(res));
   }
-
 }
 ```

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ public class WidgetController$Route implements HttpService {
     var pathParams = req.path().pathParameters();
     int id = asInt(pathParams.first("id").get());
     var result = controller.getById(id);
-    res.headers().contentType(io.helidon.common.http.HttpMediaType.APPLICATION_JSON);
+    res.headers().contentType(HttpMediaType.APPLICATION_JSON);
     widgetJsonType.toJson(result, JsonOutput.of(res));
   }
 

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -20,7 +20,6 @@ import javax.lang.model.element.TypeElement;
 import io.avaje.http.generator.core.ClientPrism;
 import io.avaje.http.generator.core.ControllerReader;
 import io.avaje.http.generator.core.ImportPrism;
-import io.avaje.http.generator.core.JsonBUtil;
 import io.avaje.http.generator.core.ProcessingContext;
 
 @SupportedAnnotationTypes({ClientPrism.PRISM_TYPE, ImportPrism.PRISM_TYPE})
@@ -28,19 +27,11 @@ public class ClientProcessor extends AbstractProcessor {
 
   private final ComponentMetaData metaData = new ComponentMetaData();
 
-  private final boolean useJsonB;
+  private boolean useJsonB;
 
   private SimpleComponentWriter componentWriter;
 
   private boolean readModuleInfo;
-
-  public ClientProcessor() {
-    useJsonB = JsonBUtil.detectJsonb();
-  }
-
-  public ClientProcessor(boolean useJsonb) {
-    useJsonB = useJsonb;
-  }
 
   @Override
   public SourceVersion getSupportedSourceVersion() {
@@ -52,8 +43,8 @@ public class ClientProcessor extends AbstractProcessor {
     super.init(processingEnv);
     this.processingEnv = processingEnv;
     ProcessingContext.init(processingEnv, new ClientPlatformAdapter(), false);
-
     this.componentWriter = new SimpleComponentWriter(metaData);
+    useJsonB = ProcessingContext.useJsonb();
   }
 
   @Override

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
@@ -14,6 +14,8 @@ import javax.lang.model.element.TypeElement;
 @SupportedOptions({"useJavax", "useSingleton", "instrumentRequests","disableDirectWrites"})
 public abstract class BaseProcessor extends AbstractProcessor {
 
+  protected boolean useJsonB;
+
   @Override
   public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latest();
@@ -28,6 +30,7 @@ public abstract class BaseProcessor extends AbstractProcessor {
   public synchronized void init(ProcessingEnvironment processingEnv) {
     super.init(processingEnv);
     ProcessingContext.init(processingEnv, providePlatformAdapter());
+    useJsonB = ProcessingContext.useJsonb();
   }
 
   /** Provide the platform specific adapter to use for Javalin, Helidon etc. */
@@ -44,7 +47,7 @@ public abstract class BaseProcessor extends AbstractProcessor {
 
     final Set<? extends Element> controllers =
         round.getElementsAnnotatedWith(typeElement(ControllerPrism.PRISM_TYPE));
-    for (Element controller : controllers) {
+    for (final Element controller : controllers) {
       writeAdapter(controller);
     }
 
@@ -57,7 +60,7 @@ public abstract class BaseProcessor extends AbstractProcessor {
   private void readOpenApiDefinition(RoundEnvironment round) {
     final Set<? extends Element> elements =
         round.getElementsAnnotatedWith(typeElement(OpenAPIDefinitionPrism.PRISM_TYPE));
-    for (Element element : elements) {
+    for (final Element element : elements) {
       doc().readApiDefinition(element);
     }
   }
@@ -65,24 +68,24 @@ public abstract class BaseProcessor extends AbstractProcessor {
   private void readTagDefinitions(RoundEnvironment round) {
     Set<? extends Element> elements =
         round.getElementsAnnotatedWith(typeElement(TagPrism.PRISM_TYPE));
-    for (Element element : elements) {
+    for (final Element element : elements) {
       doc().addTagDefinition(element);
     }
 
     elements = round.getElementsAnnotatedWith(typeElement(TagsPrism.PRISM_TYPE));
-    for (Element element : elements) {
+    for (final Element element : elements) {
       doc().addTagsDefinition(element);
     }
   }
 
   private void readSecuritySchemes(RoundEnvironment round) {
     Set<? extends Element> elements = round.getElementsAnnotatedWith(typeElement(SecuritySchemePrism.PRISM_TYPE));
-    for (Element element : elements) {
+    for (final Element element : elements) {
         doc().addSecurityScheme(element);
     }
 
     elements = round.getElementsAnnotatedWith(typeElement(SecuritySchemesPrism.PRISM_TYPE));
-    for (Element element : elements) {
+    for (final Element element : elements) {
         doc().addSecuritySchemes(element);
     }
   }
@@ -93,11 +96,11 @@ public abstract class BaseProcessor extends AbstractProcessor {
 
   private void writeAdapter(Element controller) {
     if (controller instanceof TypeElement) {
-      ControllerReader reader = new ControllerReader((TypeElement) controller);
+      final ControllerReader reader = new ControllerReader((TypeElement) controller);
       reader.read(true);
       try {
         writeControllerAdapter(reader);
-      } catch (Throwable e) {
+      } catch (final Throwable e) {
         e.printStackTrace();
         logError(reader.beanType(), "Failed to write $Route class " + e);
       }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/JsonBUtil.java
@@ -8,18 +8,6 @@ import java.util.stream.Collectors;
 public class JsonBUtil {
   private JsonBUtil() {}
 
-  /**
-   * Return true if avaje-jsonb is detected in the classpath.
-   */
-  public static boolean detectJsonb() {
-    try {
-      Class.forName("io.avaje.jsonb.Jsonb");
-      return true;
-    } catch (final ClassNotFoundException e) {
-      return false;
-    }
-  }
-
   public static Map<String, UType> jsonTypes(ControllerReader reader) {
 
     final Map<String, UType> jsonTypes = new LinkedHashMap<>();

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -42,6 +42,7 @@ public class ProcessingContext {
     private final String diAnnotation;
     private final boolean instrumentAllMethods;
     private final boolean disableDirectWrites;
+    private final boolean useJsonb;
 
     Ctx(ProcessingEnvironment env, PlatformAdapter adapter, boolean generateOpenAPI) {
       readAdapter = adapter;
@@ -65,7 +66,7 @@ public class ProcessingContext {
         useComponent = elementUtils.getTypeElement(Constants.COMPONENT) != null;
       }
       diAnnotation = (useComponent ? "@Component" : "@Singleton");
-
+      useJsonb = elementUtils.getTypeElement("io.avaje.jsonb.Jsonb") != null;
       final var javax = elementUtils.getTypeElement(Constants.SINGLETON_JAVAX) != null;
       final var jakarta = elementUtils.getTypeElement(Constants.SINGLETON_JAKARTA) != null;
       final var override = options.get("useJavax");
@@ -184,6 +185,10 @@ public class ProcessingContext {
 
   public static boolean instrumentAllWebMethods() {
     return CTX.get().instrumentAllMethods;
+  }
+
+  public static boolean useJsonb() {
+    return CTX.get().useJsonb;
   }
 
   public static boolean disabledDirectWrites() {

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinProcessor.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinProcessor.java
@@ -6,16 +6,6 @@ import java.io.IOException;
 
 public class JavalinProcessor extends BaseProcessor {
 
-  private final boolean useJsonB;
-
-  public JavalinProcessor() {
-    useJsonB = JsonBUtil.detectJsonb();
-  }
-
-  public JavalinProcessor(boolean useJsonb) {
-    useJsonB = useJsonb;
-  }
-
   @Override
   protected PlatformAdapter providePlatformAdapter() {
     return new JavalinAdapter(useJsonB);

--- a/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/NimaProcessor.java
+++ b/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/NimaProcessor.java
@@ -6,16 +6,6 @@ import java.io.IOException;
 
 public class NimaProcessor extends BaseProcessor {
 
-  private final boolean jsonB;
-
-  public NimaProcessor() {
-    jsonB = JsonBUtil.detectJsonb();
-  }
-
-  public NimaProcessor(boolean useJsonb) {
-    jsonB = useJsonb;
-  }
-
   @Override
   protected PlatformAdapter providePlatformAdapter() {
     return new NimaPlatformAdapter();
@@ -23,6 +13,6 @@ public class NimaProcessor extends BaseProcessor {
 
   @Override
   public void writeControllerAdapter(ControllerReader reader) throws IOException {
-    new ControllerWriter(reader, jsonB).write();
+    new ControllerWriter(reader, useJsonB).write();
   }
 }

--- a/tests/test-javalin-jsonb/src/test/java/io/avaje/http/generator/JavalinProcessorTest.java
+++ b/tests/test-javalin-jsonb/src/test/java/io/avaje/http/generator/JavalinProcessorTest.java
@@ -51,7 +51,12 @@ class JavalinProcessorTest {
 
     final var task =
         compiler.getTask(
-            new PrintWriter(System.out), null, null, List.of("--release=11"), null, files);
+            new PrintWriter(System.out),
+            null,
+            null,
+            List.of("--release=11", "-AdisableDirectWrites=true"),
+            null,
+            files);
     task.setProcessors(List.of(new JavalinProcessor()));
 
     assertThat(task.call()).isTrue();
@@ -71,7 +76,7 @@ class JavalinProcessorTest {
     final var task =
         compiler.getTask(
             new PrintWriter(System.out), null, null, List.of("--release=11"), null, files);
-    task.setProcessors(List.of(new JavalinProcessor(true), new Processor()));
+    task.setProcessors(List.of(new JavalinProcessor(), new Processor()));
 
     assertThat(task.call()).isTrue();
     assert Files.readString(
@@ -92,10 +97,14 @@ class JavalinProcessorTest {
             new PrintWriter(System.out),
             null,
             null,
-            List.of("--release=11", "-AuseJavax=true", "-AuseSingleton=true"),
+            List.of(
+                "--release=11",
+                "-AuseJavax=true",
+                "-AuseSingleton=true",
+                "-AdisableDirectWrites=true"),
             null,
             files);
-    task.setProcessors(List.of(new JavalinProcessor(false), new Processor()));
+    task.setProcessors(List.of(new JavalinProcessor(), new Processor()));
     // we don't have javax on the cp
     assertThat(task.call()).isFalse();
 
@@ -117,10 +126,14 @@ class JavalinProcessorTest {
             new PrintWriter(System.out),
             null,
             null,
-            List.of("--release=11", "-AuseJavax=false", "-AuseSingleton=true"),
+            List.of(
+                "--release=11",
+                "-AuseJavax=false",
+                "-AuseSingleton=true",
+                "-AdisableDirectWrites=true"),
             null,
             files);
-    task.setProcessors(List.of(new JavalinProcessor(false), new Processor()));
+    task.setProcessors(List.of(new JavalinProcessor(), new Processor()));
 
     assertThat(task.call()).isTrue();
 
@@ -147,10 +160,10 @@ class JavalinProcessorTest {
             new PrintWriter(System.out),
             null,
             null,
-            List.of("--release=11"),
+            List.of("--release=11", "-AdisableDirectWrites=true"),
             null,
             openAPIController);
-    task.setProcessors(List.of(new JavalinProcessor(false), new Processor()));
+    task.setProcessors(List.of(new JavalinProcessor(), new Processor()));
 
     assertThat(task.call()).isTrue();
 
@@ -181,10 +194,10 @@ class JavalinProcessorTest {
             new PrintWriter(System.out),
             null,
             null,
-            List.of("--release=11"),
+            List.of("--release=11", "-AdisableDirectWrites=true"),
             null,
             openAPIController);
-    task.setProcessors(List.of(new JavalinProcessor(false), new Processor()));
+    task.setProcessors(List.of(new JavalinProcessor(), new Processor()));
 
     assertThat(task.call()).isTrue();
 
@@ -195,7 +208,6 @@ class JavalinProcessorTest {
 
     assert expectedOpenApiJson.equals(generatedOpenApi);
   }
-
 
   private Iterable<JavaFileObject> getSourceFiles(String source) throws Exception {
     final var compiler = ToolProvider.getSystemJavaCompiler();

--- a/tests/test-nima-jsonb/src/test/java/io/avaje/http/generator/NimaProcessorTest.java
+++ b/tests/test-nima-jsonb/src/test/java/io/avaje/http/generator/NimaProcessorTest.java
@@ -45,8 +45,8 @@ class NimaProcessorTest {
 
     final var task =
         compiler.getTask(
-            new PrintWriter(System.out), null, null, List.of("--release=19"), null, files);
-    task.setProcessors(List.of(new NimaProcessor(false)));
+            new PrintWriter(System.out), null, null, List.of("--release=20", "-AdisableDirectWrites=true"), null, files);
+    task.setProcessors(List.of(new NimaProcessor()));
 
     assertThat(task.call()).isTrue();
   }


### PR DESCRIPTION
When you add the generators as a provided dependency on a modular project, the use of `Class.forName` to detect classes doesn't fly.