### PR TITLE
Add Accept Language header to validation

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/Valid.java
+++ b/http-api/src/main/java/io/avaje/http/api/Valid.java
@@ -9,18 +9,23 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Add {@code @Valid} annotation on a controller/method/BeanParam that we want bean validation to
- * be included for. When we do this controller methods that take a request payload will then have
- * the request bean (populated by JSON payload or form parameters) validated before it is passed
- * to the controller method.
- * <p>
- * When trying to validate a {@code @BeanParam} bean, this will need to be placed on the BeanParam type.
- * <p>
- * When using this annotation we need to provide an implementation of {@link Validator} to use.
- * <p>
- * Alternatively we can use the Jakarta {@code @Valid} along with a Jakarta validator implementation.
+ * Add {@code @Valid} annotation on a controller/method/BeanParam that we want bean validation to be
+ * included for. When we do this controller methods that take a request payload will then have the
+ * request bean (populated by JSON payload or form parameters) validated before it is passed to the
+ * controller method.
+ *
+ * <p>When trying to validate a {@code @BeanParam} bean, this will need to be placed on the
+ * BeanParam type.
+ *
+ * <p>When using this annotation we need to provide an implementation of {@link Validator} to use.
+ *
+ * <p>Alternatively we can use the Jakarta {@code @Valid} along with a Jakarta validator
+ * implementation.
  */
 @Retention(SOURCE)
 @Target({METHOD, TYPE, PARAMETER})
 public @interface Valid {
+
+  /** Validation groups to use */
+  Class<?>[] groups() default {};
 }

--- a/http-api/src/main/java/io/avaje/http/api/Validator.java
+++ b/http-api/src/main/java/io/avaje/http/api/Validator.java
@@ -1,17 +1,28 @@
 package io.avaje.http.api;
 
-/**
- * Validator for form beans or request beans.
- */
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Locale.LanguageRange;
+
+/** Validator for form beans or request beans. */
 public interface Validator {
 
   /**
    * Validate the bean throwing an exception if the bean fails validation.
-   * <p>
-   * Typically the exception will be handled by a specific exception handler
-   * returning a 422 or 400 status code and usually a map of field paths to error messages.
+   *
+   * <p>Typically the exception will be handled by a specific exception handler returning a 422 or
+   * 400 status code and usually a map of field paths to error messages.
    *
    * @param bean The bean to validate
    */
-  void validate(Object bean);
+  void validate(Object bean, String acceptLanguage, Class<?>... groups) throws ValidationException;
+
+  default Locale resolveLocale(String acceptLanguage, Collection<Locale> locales) {
+    if (acceptLanguage == null) {
+      return null;
+    }
+    final List<LanguageRange> list = LanguageRange.parse(acceptLanguage);
+    return Locale.lookup(list, locales);
+  }
 }

--- a/http-api/src/main/java/io/avaje/http/api/Validator.java
+++ b/http-api/src/main/java/io/avaje/http/api/Validator.java
@@ -18,11 +18,11 @@ public interface Validator {
    */
   void validate(Object bean, String acceptLanguage, Class<?>... groups) throws ValidationException;
 
-  default Locale resolveLocale(String acceptLanguage, Collection<Locale> locales) {
+  default Locale resolveLocale(String acceptLanguage, Collection<Locale> acceptLocales) {
     if (acceptLanguage == null) {
       return null;
     }
     final List<LanguageRange> list = LanguageRange.parse(acceptLanguage);
-    return Locale.lookup(list, locales);
+    return Locale.lookup(list, acceptLocales);
   }
 }

--- a/http-client/src/test/java/org/example/webserver/HelloController$Route.java
+++ b/http-client/src/test/java/org/example/webserver/HelloController$Route.java
@@ -64,16 +64,16 @@ public class HelloController$Route implements WebRoutes {
 
     ApiBuilder.post("/hello", ctx -> {
       ctx.status(201);
-      HelloDto dto = ctx.bodyAsClass(HelloDto.class);
-      validator.validate(dto);
+      final HelloDto dto = ctx.bodyAsClass(HelloDto.class);
+      validator.validate(dto, "en-us");
       ctx.json(controller.post(dto));
     });
 
     ApiBuilder.post("/hello/savebean/{foo}", ctx -> {
       ctx.status(201);
-      String foo = ctx.pathParam("foo");
-      HelloDto dto = ctx.bodyAsClass(HelloDto.class);
-      validator.validate(dto);
+      final String foo = ctx.pathParam("foo");
+      final HelloDto dto = ctx.bodyAsClass(HelloDto.class);
+      validator.validate(dto, "en-us");
       controller.saveBean(foo, dto, ctx);
     });
 
@@ -86,7 +86,7 @@ public class HelloController$Route implements WebRoutes {
       helloForm.url = ctx.formParam("url");
       helloForm.startDate = toLocalDate(ctx.formParam("startDate"));
 
-      validator.validate(helloForm);
+      validator.validate(helloForm, "en-us");
       controller.saveForm(helloForm);
     });
 
@@ -107,7 +107,7 @@ public class HelloController$Route implements WebRoutes {
       helloForm.url = ctx.formParam("url");
       helloForm.startDate = toLocalDate(ctx.formParam("startDate"));
 
-      validator.validate(helloForm);
+      validator.validate(helloForm, "en-us");
       ctx.json(controller.saveForm3(helloForm));
     });
 

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientPlatformAdapter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientPlatformAdapter.java
@@ -34,24 +34,20 @@ class ClientPlatformAdapter implements PlatformAdapter {
   public String indent() {
     return null;
   }
+  // these have no meaning for client adapters
+  @Override
+  public void controllerRoles(List<String> roles, ControllerReader controller) {}
 
   @Override
-  public void controllerRoles(List<String> roles, ControllerReader controller) {
-
-  }
+  public void methodRoles(List<String> roles, ControllerReader controller) {}
 
   @Override
-  public void methodRoles(List<String> roles, ControllerReader controller) {
-
-  }
+  public void writeReadParameter(Append writer, ParamType paramType, String paramName) {}
 
   @Override
-  public void writeReadParameter(Append writer, ParamType paramType, String paramName) {
-
-  }
+  public void writeReadParameter(
+      Append writer, ParamType paramType, String paramName, String paramDefault) {}
 
   @Override
-  public void writeReadParameter(Append writer, ParamType paramType, String paramName, String paramDefault) {
-
-  }
+  public void writeAcceptLanguage(Append writer) {}
 }

--- a/http-generator-core/pom.xml
+++ b/http-generator-core/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>avaje-http-generator-core</artifactId>
 
   <properties>
-    <avaje.prisms.version>1.9</avaje.prisms.version>
+    <avaje.prisms.version>1.10</avaje.prisms.version>
   </properties>
   <dependencies>
     <dependency>

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/Constants.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/Constants.java
@@ -19,6 +19,7 @@ public class Constants {
   static final String IMPORT_HTTP_API = "io.avaje.http.api.*";
   static final String VALIDATOR = "io.avaje.http.api.Validator";
   public static final String META_INF_COMPONENT = "META-INF/services/io.avaje.http.client.HttpClient$GeneratedComponent";
+  public static final String ACCEPT_LANGUAGE = "Accept-Language";
 
 
 }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerReader.java
@@ -180,9 +180,7 @@ public final class ControllerReader {
 
   private boolean initHasValid() {
 
-    return findAnnotation(JavaxValidPrism::getOptionalOn).isPresent()
-        || findAnnotation(JakartaValidPrism::getOptionalOn).isPresent()
-        || findAnnotation(ValidPrism::getOptionalOn).isPresent();
+    return findAnnotation(ValidPrism::getOptionalOn).isPresent();
   }
 
   String produces() {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
@@ -126,18 +126,12 @@ public class MethodReader {
   }
 
   private boolean initValid() {
-    return findAnnotation(ValidPrism::getOptionalOn).isPresent()
-        || findAnnotation(JavaxValidPrism::getOptionalOn).isPresent()
-        || findAnnotation(JakartaValidPrism::getOptionalOn).isPresent()
-        || superMethodHasValid();
+    return findAnnotation(ValidPrism::getOptionalOn).isPresent() || superMethodHasValid();
   }
 
   private boolean superMethodHasValid() {
     return superMethods.stream()
-        .anyMatch(
-            e ->
-                findAnnotation(ValidPrism::getOptionalOn).isPresent()
-                    || findAnnotation(JavaxValidPrism::getOptionalOn).isPresent());
+        .anyMatch(e -> findAnnotation(ValidPrism::getOptionalOn).isPresent());
   }
 
   @Override

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/PlatformAdapter.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/PlatformAdapter.java
@@ -48,6 +48,8 @@ public interface PlatformAdapter {
   void writeReadParameter(
       Append writer, ParamType paramType, String paramName, String paramDefault);
 
+  void writeAcceptLanguage(Append writer);
+
   default void writeReadMapParameter(Append writer, ParamType paramType) {
     throw new UnsupportedOperationException("Unsupported Map Parameter");
   }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ValidPrism.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ValidPrism.java
@@ -1,0 +1,35 @@
+package io.avaje.http.generator.core;
+
+import java.util.Optional;
+
+import javax.lang.model.element.Element;
+
+import io.avaje.prism.GeneratePrism;
+
+@GeneratePrism(
+    value = javax.validation.Valid.class,
+    name = "JavaxValidPrism",
+    superInterfaces = ValidPrism.class)
+@GeneratePrism(
+    value = jakarta.validation.Valid.class,
+    name = "JakartaValidPrism",
+    superInterfaces = ValidPrism.class)
+@GeneratePrism(
+    value = io.avaje.http.api.Valid.class,
+    name = "HttpValidPrism",
+    superInterfaces = ValidPrism.class)
+public interface ValidPrism {
+
+  static Optional<ValidPrism> getOptionalOn(Element e) {
+    return Optional.<ValidPrism>empty()
+        .or(() -> HttpValidPrism.getOptionalOn(e))
+        .or(() -> JakartaValidPrism.getOptionalOn(e))
+        .or(() -> JavaxValidPrism.getOptionalOn(e));
+  }
+
+  static boolean isPresent(Element e) {
+    return JakartaValidPrism.isPresent(e)
+        || JavaxValidPrism.isPresent(e)
+        || HttpValidPrism.isPresent(e);
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
@@ -35,9 +35,6 @@
 @GeneratePrism(value = io.avaje.http.api.Client.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Client.Import.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.RequestTimeout.class, publicAccess = true)
-@GeneratePrism(value = javax.validation.Valid.class, name = "JavaxValidPrism")
-@GeneratePrism(value = jakarta.validation.Valid.class, name = "JakartaValidPrism")
-@GeneratePrism(value = io.avaje.http.api.Valid.class)
 package io.avaje.http.generator.core;
 
 import io.avaje.prism.GeneratePrism;

--- a/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/HelidonPlatformAdapter.java
+++ b/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/HelidonPlatformAdapter.java
@@ -3,6 +3,7 @@ package io.avaje.http.generator.helidon;
 import java.util.List;
 
 import io.avaje.http.generator.core.Append;
+import io.avaje.http.generator.core.Constants;
 import io.avaje.http.generator.core.ControllerReader;
 import io.avaje.http.generator.core.ParamType;
 import io.avaje.http.generator.core.PlatformAdapter;
@@ -167,5 +168,10 @@ class HelidonPlatformAdapter implements PlatformAdapter {
       default:
         throw new UnsupportedOperationException("Unsupported MultiValue Parameter");
     }
+  }
+  
+  @Override
+  public void writeAcceptLanguage(Append writer) {
+    writer.append("req.headers().first(\"%s\").orElse(null)", Constants.ACCEPT_LANGUAGE);
   }
 }

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinAdapter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinAdapter.java
@@ -3,6 +3,7 @@ package io.avaje.http.generator.javalin;
 import java.util.List;
 
 import io.avaje.http.generator.core.Append;
+import io.avaje.http.generator.core.Constants;
 import io.avaje.http.generator.core.ControllerReader;
 import io.avaje.http.generator.core.ParamType;
 import io.avaje.http.generator.core.PlatformAdapter;
@@ -107,5 +108,10 @@ class JavalinAdapter implements PlatformAdapter {
           "Only MultiValue Query Params are supported in Javalin");
     }
     writer.append("withDefault(ctx.queryParams(\"%s\"), java.util.List.of(\"%s\"))", paramName, String.join(",", paramDefault));
+  }
+
+  @Override
+  public void writeAcceptLanguage(Append writer) {
+    writer.append("ctx.header(\"%s\")", Constants.ACCEPT_LANGUAGE);
   }
 }

--- a/http-generator-jex/src/main/java/io/avaje/http/generator/jex/JexAdapter.java
+++ b/http-generator-jex/src/main/java/io/avaje/http/generator/jex/JexAdapter.java
@@ -3,6 +3,7 @@ package io.avaje.http.generator.jex;
 import java.util.List;
 
 import io.avaje.http.generator.core.Append;
+import io.avaje.http.generator.core.Constants;
 import io.avaje.http.generator.core.ControllerReader;
 import io.avaje.http.generator.core.ParamType;
 import io.avaje.http.generator.core.PlatformAdapter;
@@ -83,5 +84,10 @@ class JexAdapter implements PlatformAdapter {
           "Only MultiValue Query Params are supported in Jex");
     }
     writer.append("withDefault(ctx.queryParams(\"%s\"), java.util.List.of(\"%s\"))", paramName, String.join(",", paramDefault));
+  }
+  
+  @Override
+  public void writeAcceptLanguage(Append writer) {
+    writer.append("ctx.header(\"%s\")", Constants.ACCEPT_LANGUAGE);
   }
 }

--- a/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
+++ b/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
@@ -45,6 +45,7 @@ class ControllerWriter extends BaseControllerWriter {
     reader.addImportType("io.helidon.nima.webserver.http.ServerRequest");
     reader.addImportType("io.helidon.nima.webserver.http.ServerResponse");
     reader.addImportType("io.helidon.nima.webserver.http.HttpService");
+    reader.addImportType("io.helidon.common.http.Http.Header");
   }
 
   void write() {

--- a/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/NimaPlatformAdapter.java
+++ b/http-generator-nima/src/main/java/io/avaje/http/generator/helidon/nima/NimaPlatformAdapter.java
@@ -71,7 +71,7 @@ class NimaPlatformAdapter implements PlatformAdapter {
         writer.append("formParams.first(\"%s\").orElse(null)", paramName);
         break;
       case HEADER:
-        writer.append("req.headers().value(io.helidon.common.http.Http.Header.create(\"%s\")).orElse(null)", paramName);
+        writer.append("req.headers().value(Header.create(\"%s\")).orElse(null)", paramName);
         break;
       case COOKIE:
         writer.append("req.headers().cookies().first(\"%s\").orElse(null)", paramName);
@@ -158,5 +158,10 @@ class NimaPlatformAdapter implements PlatformAdapter {
       default:
         throw new UnsupportedOperationException("Unsupported MultiValue Parameter");
     }
+  }
+
+  @Override
+  public void writeAcceptLanguage(Append writer) {
+    writer.append("req.headers().first(Header.create(\"%s\")).orElse(null)", Constants.ACCEPT_LANGUAGE);
   }
 }

--- a/http-hibernate-validator/pom.xml
+++ b/http-hibernate-validator/pom.xml
@@ -36,14 +36,14 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.30</version>
+      <version>1.45-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>9.0</version>
+      <version>9.3</version>
       <scope>provided</scope>
     </dependency>
 

--- a/http-hibernate-validator/src/main/java/io/avaje/http/hibernate/validator/BeanValidator.java
+++ b/http-hibernate-validator/src/main/java/io/avaje/http/hibernate/validator/BeanValidator.java
@@ -1,6 +1,5 @@
 package io.avaje.http.hibernate.validator;
 
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -16,8 +15,11 @@ public class BeanValidator implements Validator {
   private static final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 
   @Override
-  public void validate(Object bean) {
-    final Set<ConstraintViolation<Object>> violations = factory.getValidator().validate(bean);
+  public void validate(Object bean, String acceptLanguage, Class<?>... groups)
+      throws ValidationException {
+
+    final Set<ConstraintViolation<Object>> violations =
+        factory.getValidator().validate(bean, groups);
     if (!violations.isEmpty()) {
       throwExceptionWith(violations);
     }

--- a/tests/test-javalin-jsonb/pom.xml
+++ b/tests/test-javalin-jsonb/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>2.8</version>
+      <version>3.2</version>
     </dependency>
 
     <dependency>

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/GetBeanForm.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/GetBeanForm.java
@@ -3,15 +3,14 @@ package org.example.myapp.web;
 import java.util.List;
 import java.util.Set;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-
 import io.avaje.http.api.Header;
 import io.avaje.http.api.Ignore;
 import io.avaje.http.api.QueryParam;
 import io.avaje.jsonb.Json;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Json
 @Valid

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/HelloForm.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/HelloForm.java
@@ -2,15 +2,14 @@ package org.example.myapp.web;
 
 import java.time.LocalDate;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Future;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-
 import org.hibernate.validator.constraints.URL;
 
 import io.avaje.jsonb.Json;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Json
 @Valid

--- a/tests/test-javalin/pom.xml
+++ b/tests/test-javalin/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>2.8</version>
+      <version>3.2</version>
     </dependency>
 
     <dependency>

--- a/tests/test-javalin/src/main/java/org/example/myapp/web/GetBeanForm.java
+++ b/tests/test-javalin/src/main/java/org/example/myapp/web/GetBeanForm.java
@@ -1,9 +1,9 @@
 package org.example.myapp.web;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Valid
 public class GetBeanForm {

--- a/tests/test-javalin/src/main/java/org/example/myapp/web/HelloController.java
+++ b/tests/test-javalin/src/main/java/org/example/myapp/web/HelloController.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 
-import javax.validation.Valid;
-
 import org.example.myapp.service.MyService;
 
 import io.avaje.http.api.BeanParam;
@@ -26,6 +24,7 @@ import io.avaje.http.api.QueryParam;
 import io.javalin.http.Context;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.inject.Inject;
+import jakarta.validation.Valid;
 
 /**
  * Hello resource manager.

--- a/tests/test-javalin/src/main/java/org/example/myapp/web/HelloForm.java
+++ b/tests/test-javalin/src/main/java/org/example/myapp/web/HelloForm.java
@@ -1,13 +1,14 @@
 package org.example.myapp.web;
 
+import java.time.LocalDate;
+
 import org.hibernate.validator.constraints.URL;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Future;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-import java.time.LocalDate;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Valid
 public class HelloForm {

--- a/tests/test-jex/pom.xml
+++ b/tests/test-jex/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>2.8</version>
+      <version>3.2</version>
     </dependency>
 
     <dependency>

--- a/tests/test-jex/src/main/java/org/example/web/HelloController.java
+++ b/tests/test-jex/src/main/java/org/example/web/HelloController.java
@@ -1,9 +1,13 @@
 package org.example.web;
 
-import io.avaje.http.api.*;
+import io.avaje.http.api.Controller;
+import io.avaje.http.api.Default;
+import io.avaje.http.api.Get;
+import io.avaje.http.api.Path;
+import io.avaje.http.api.Produces;
+import io.avaje.http.api.Put;
+import io.avaje.http.api.Valid;
 import io.avaje.jex.Context;
-
-import javax.validation.Valid;
 
 // @Roles(AppRoles.BASIC_USER)
 @Controller

--- a/tests/test-jex/src/main/java/org/example/web/HelloDto.java
+++ b/tests/test-jex/src/main/java/org/example/web/HelloDto.java
@@ -1,7 +1,7 @@
 package org.example.web;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 @Valid
 public class HelloDto {


### PR DESCRIPTION
In preparation for Avaje Validation:

- Modifies Validator interface to accept language headers and adds a method to resolve locales
- Modify Hibernate Validator to match
- Modify Generation to extract language header and groups for validation