### PR TITLE
Change ValidationException errors to be a List<ValidationException.Error>

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/ValidationException.java
+++ b/http-api/src/main/java/io/avaje/http/api/ValidationException.java
@@ -1,6 +1,7 @@
 package io.avaje.http.api;
 
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Exception used with Validator.
@@ -8,7 +9,7 @@ import java.util.Map;
  * <p>Typically this is used when validating a bean populated by request body content.
  *
  * <p>Generally this exception type is registered with an exception handler and configured to return
- * a 422 or 400 http status response with the errors as a map of fields to error message.
+ * a 422 or 400 http status response with the errors as a list of field error message.
  */
 public class ValidationException extends IllegalArgumentException {
 
@@ -16,28 +17,30 @@ public class ValidationException extends IllegalArgumentException {
 
   private int status = 422;
 
-  private Map<String, Object> errors;
+  private List<? extends Error> errors;
 
   /** Create with a message. */
   public ValidationException(String message) {
     super(message);
+    this.errors = new ArrayList<>();
   }
 
   /** Create with a status and message. */
   public ValidationException(int status, String message) {
     super(message);
     this.status = status;
+    this.errors = new ArrayList<>();
   }
 
   /** Create with a status message and errors. */
-  public ValidationException(int status, String message, Map<String, Object> errors) {
+  public ValidationException(int status, String message, List<? extends Error> errors) {
     super(message);
     this.status = status;
     this.errors = errors;
   }
 
   /** Create with a status message and errors. */
-  public ValidationException(int status, String message, Throwable cause, Map<String, Object> errors) {
+  public ValidationException(int status, String message, Throwable cause, List<? extends Error> errors) {
     super(message, cause);
     this.status = status;
     this.errors = errors;
@@ -54,12 +57,59 @@ public class ValidationException extends IllegalArgumentException {
   }
 
   /** Return the errors typically as a map of field to error message. */
-  public Map<String, Object> getErrors() {
+  public List<? extends Error> getErrors() {
     return errors;
   }
 
   /** Set the errors. */
-  public void setErrors(Map<String, Object> errors) {
+  public void setErrors(List<? extends Error> errors) {
     this.errors = errors;
+  }
+
+  /** Error details including the field, error message and path */
+  public static class Error {
+
+    protected String path;
+    protected String field;
+    protected String message;
+
+    public Error(String path, String field, String message) {
+      this.path = path;
+      this.field = field;
+      this.message = message;
+    }
+
+    public Error() {
+    }
+
+    /** Return the path of this error message. */
+    public String getPath() {
+      return path;
+    }
+
+    /** Return the field for this error message. */
+    public String getField() {
+      return field;
+    }
+
+    /** Return the error message. */
+    public String getMessage() {
+      return message;
+    }
+
+    /** Set the path for this error. */
+    public void setPath(String path) {
+      this.path = path;
+    }
+
+    /** Set the field for this error. */
+    public void setField(String field) {
+      this.field = field;
+    }
+
+    /** Set the error message. */
+    public void setMessage(String message) {
+      this.message = message;
+    }
   }
 }

--- a/http-api/src/main/java/io/avaje/http/api/ValidationException.java
+++ b/http-api/src/main/java/io/avaje/http/api/ValidationException.java
@@ -17,7 +17,7 @@ public class ValidationException extends IllegalArgumentException {
 
   private int status = 422;
 
-  private List<? extends Error> errors;
+  private List<? extends ViolationMessage> errors;
 
   /** Create with a message. */
   public ValidationException(String message) {
@@ -33,14 +33,14 @@ public class ValidationException extends IllegalArgumentException {
   }
 
   /** Create with a status message and errors. */
-  public ValidationException(int status, String message, List<? extends Error> errors) {
+  public ValidationException(int status, String message, List<? extends ViolationMessage> errors) {
     super(message);
     this.status = status;
     this.errors = errors;
   }
 
   /** Create with a status message and errors. */
-  public ValidationException(int status, String message, Throwable cause, List<? extends Error> errors) {
+  public ValidationException(int status, String message, Throwable cause, List<? extends ViolationMessage> errors) {
     super(message, cause);
     this.status = status;
     this.errors = errors;
@@ -57,29 +57,29 @@ public class ValidationException extends IllegalArgumentException {
   }
 
   /** Return the errors typically as a map of field to error message. */
-  public List<? extends Error> getErrors() {
+  public List<? extends ViolationMessage> getErrors() {
     return errors;
   }
 
   /** Set the errors. */
-  public void setErrors(List<? extends Error> errors) {
+  public void setErrors(List<? extends ViolationMessage> errors) {
     this.errors = errors;
   }
 
   /** Error details including the field, error message and path */
-  public static class Error {
+  public static class ViolationMessage {
 
     protected String path;
     protected String field;
     protected String message;
 
-    public Error(String path, String field, String message) {
+    public ViolationMessage(String path, String field, String message) {
       this.path = path;
       this.field = field;
       this.message = message;
     }
 
-    public Error() {
+    public ViolationMessage() {
     }
 
     /** Return the path of this error message. */

--- a/http-api/src/main/java/io/avaje/http/api/ValidationException.java
+++ b/http-api/src/main/java/io/avaje/http/api/ValidationException.java
@@ -17,7 +17,7 @@ public class ValidationException extends IllegalArgumentException {
 
   private int status = 422;
 
-  private List<? extends ViolationMessage> errors;
+  private List<? extends Violation> errors;
 
   /** Create with a message. */
   public ValidationException(String message) {
@@ -33,14 +33,14 @@ public class ValidationException extends IllegalArgumentException {
   }
 
   /** Create with a status message and errors. */
-  public ValidationException(int status, String message, List<? extends ViolationMessage> errors) {
+  public ValidationException(int status, String message, List<? extends Violation> errors) {
     super(message);
     this.status = status;
     this.errors = errors;
   }
 
   /** Create with a status message and errors. */
-  public ValidationException(int status, String message, Throwable cause, List<? extends ViolationMessage> errors) {
+  public ValidationException(int status, String message, Throwable cause, List<? extends Violation> errors) {
     super(message, cause);
     this.status = status;
     this.errors = errors;
@@ -57,29 +57,29 @@ public class ValidationException extends IllegalArgumentException {
   }
 
   /** Return the errors typically as a map of field to error message. */
-  public List<? extends ViolationMessage> getErrors() {
+  public List<? extends Violation> getErrors() {
     return errors;
   }
 
   /** Set the errors. */
-  public void setErrors(List<? extends ViolationMessage> errors) {
+  public void setErrors(List<? extends Violation> errors) {
     this.errors = errors;
   }
 
   /** Error details including the field, error message and path */
-  public static class ViolationMessage {
+  public static class Violation {
 
     protected String path;
     protected String field;
     protected String message;
 
-    public ViolationMessage(String path, String field, String message) {
+    public Violation(String path, String field, String message) {
       this.path = path;
       this.field = field;
       this.message = message;
     }
 
-    public ViolationMessage() {
+    public Violation() {
     }
 
     /** Return the path of this error message. */

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -36,14 +36,14 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
-      <version>1.4</version>
+      <version>1.7-RC1</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>9.0</version>
+      <version>9.4</version>
       <optional>true</optional>
     </dependency>
 
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.3</version>
+      <version>3.5-RC1</version>
       <scope>test</scope>
     </dependency>
 
@@ -106,7 +106,7 @@
                 <path>
                   <groupId>io.avaje</groupId>
                   <artifactId>avaje-inject-generator</artifactId>
-                  <version>9.0</version>
+                  <version>9.4</version>
                 </path>
               </annotationProcessorPaths>
             </configuration>

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.5-RC2</version>
+      <version>3.5-RC3</version>
       <scope>test</scope>
     </dependency>
 

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.5-RC1</version>
+      <version>3.5-RC2</version>
       <scope>test</scope>
     </dependency>
 

--- a/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -516,8 +516,7 @@ class HelloControllerTest extends BaseWebTest {
 
     // convert json error response body to a bean
     final ErrorResponse errorResponse = httpException.bean(ErrorResponse.class);
-    final Map<String, String> errorMap = errorResponse.getErrors();
-    assertThat(errorMap.get("email")).isEqualTo("must be a well-formed email address");
+    assertThat(errorResponse.get("email")).isEqualTo("must be a well-formed email address");
   }
 
   @Test
@@ -535,8 +534,7 @@ class HelloControllerTest extends BaseWebTest {
     final ErrorResponse errorResponse = clientContext.bodyAdapter()
       .beanReader(ErrorResponse.class).readBody(hres.body());
 
-    final Map<String, String> errorMap = errorResponse.getErrors();
-    assertThat(errorMap.get("email")).isEqualTo("must be a well-formed email address");
+    assertThat(errorResponse.get("email")).isEqualTo("must be a well-formed email address");
   }
 
   @Test
@@ -926,9 +924,8 @@ class HelloControllerTest extends BaseWebTest {
         // convert json error response body to a bean
         final ErrorResponse errorResponse = httpException.bean(ErrorResponse.class);
 
-        final Map<String, String> errorMap = errorResponse.getErrors();
-        assertThat(errorMap.get("url")).isEqualTo("must be a valid URL");
-        assertThat(errorMap.get("email")).isEqualTo("must be a well-formed email address");
+        assertThat(errorResponse.get("url")).isEqualTo("must be a valid URL");
+        assertThat(errorResponse.get("email")).isEqualTo("must be a well-formed email address");
       });
 
     try {
@@ -1129,10 +1126,8 @@ class HelloControllerTest extends BaseWebTest {
       assertEquals(422, httpResponse.statusCode());
 
       final ErrorResponse errorResponse = e.bean(ErrorResponse.class);
-
-      final Map<String, String> errorMap = errorResponse.getErrors();
-      assertThat(errorMap.get("url")).isEqualTo("must be a valid URL");
-      assertThat(errorMap.get("name")).isEqualTo("must not be null");
+      assertThat(errorResponse.get("url")).isEqualTo("must be a valid URL");
+      assertThat(errorResponse.get("name")).isEqualTo("must not be null");
     }
   }
 
@@ -1158,9 +1153,8 @@ class HelloControllerTest extends BaseWebTest {
           assertEquals(422, httpResponse.statusCode());
 
           final ErrorResponse errorResponse = cause.bean(ErrorResponse.class);
-          final Map<String, String> errorMap = errorResponse.getErrors();
-          assertThat(errorMap.get("url")).isEqualTo("must be a valid URL");
-          assertThat(errorMap.get("name")).isEqualTo("must not be null");
+          assertThat(errorResponse.get("url")).isEqualTo("must be a valid URL");
+          assertThat(errorResponse.get("name")).isEqualTo("must not be null");
         });
 
     try {
@@ -1193,9 +1187,8 @@ class HelloControllerTest extends BaseWebTest {
           assertEquals(422, httpResponse.statusCode());
 
           final ErrorResponse errorResponse = cause.bean(ErrorResponse.class);
-          final Map<String, String> errorMap = errorResponse.getErrors();
-          assertThat(errorMap.get("url")).isEqualTo("must be a valid URL");
-          assertThat(errorMap.get("name")).isEqualTo("must not be null");
+          assertThat(errorResponse.get("url")).isEqualTo("must be a valid URL");
+          assertThat(errorResponse.get("name")).isEqualTo("must not be null");
         });
 
     try {
@@ -1224,9 +1217,8 @@ class HelloControllerTest extends BaseWebTest {
       assertEquals(422, httpResponse.statusCode());
 
       final ErrorResponse errorResponse = e.bean(ErrorResponse.class);
-      final Map<String, String> errorMap = errorResponse.getErrors();
-      assertThat(errorMap.get("url")).isEqualTo("must be a valid URL");
-      assertThat(errorMap.get("name")).isEqualTo("must not be null");
+      assertThat(errorResponse.get("url")).isEqualTo("must be a valid URL");
+      assertThat(errorResponse.get("name")).isEqualTo("must not be null");
     }
   }
 
@@ -1249,9 +1241,8 @@ class HelloControllerTest extends BaseWebTest {
       assertEquals(422, httpResponse.statusCode());
 
       final ErrorResponse errorResponse = e.bean(ErrorResponse.class);
-      final Map<String, String> errorMap = errorResponse.getErrors();
-      assertThat(errorMap.get("url")).isEqualTo("must be a valid URL");
-      assertThat(errorMap.get("name")).isEqualTo("must not be null");
+      assertThat(errorResponse.get("url")).isEqualTo("must be a valid URL");
+      assertThat(errorResponse.get("name")).isEqualTo("must not be null");
 
       String rawBody = e.bodyAsString();
       assertThat(rawBody).contains("must be a valid URL");

--- a/http-client/src/test/java/org/example/github/RepoJsonAdapter.java
+++ b/http-client/src/test/java/org/example/github/RepoJsonAdapter.java
@@ -10,7 +10,7 @@ import io.avaje.jsonb.spi.ViewBuilderAware;
 
 import java.lang.invoke.MethodHandle;
 
-public class RepoJsonAdapter extends JsonAdapter<Repo> implements ViewBuilderAware {
+public class RepoJsonAdapter implements JsonAdapter<Repo>, ViewBuilderAware {
 
   // naming convention Match
   // id [long] name:id publicField

--- a/http-client/src/test/java/org/example/webserver/ErrorResponse.java
+++ b/http-client/src/test/java/org/example/webserver/ErrorResponse.java
@@ -8,7 +8,7 @@ public class ErrorResponse {
 
   private String message;
 
-  private List<ValidationException.ViolationMessage> errors = new ArrayList<>();
+  private List<ValidationException.Violation> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -18,21 +18,21 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public List<ValidationException.ViolationMessage> getErrors() {
+  public List<ValidationException.Violation> getErrors() {
     return errors;
   }
 
-  public void setErrors(List<ValidationException.ViolationMessage> errors) {
+  public void setErrors(List<ValidationException.Violation> errors) {
     this.errors = errors;
   }
 
   public String get(String field) {
     return errorForField(field)
-      .map(ValidationException.ViolationMessage::getMessage)
+      .map(ValidationException.Violation::getMessage)
       .orElseThrow();
   }
-  public Optional<ValidationException.ViolationMessage> errorForField(String field) {
-    for (ValidationException.ViolationMessage error : errors) {
+  public Optional<ValidationException.Violation> errorForField(String field) {
+    for (ValidationException.Violation error : errors) {
       if (field.equals(error.getField())) {
         return Optional.of(error);
       }

--- a/http-client/src/test/java/org/example/webserver/ErrorResponse.java
+++ b/http-client/src/test/java/org/example/webserver/ErrorResponse.java
@@ -1,13 +1,14 @@
 package org.example.webserver;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import io.avaje.http.api.ValidationException;
+
+import java.util.*;
 
 public class ErrorResponse {
 
   private String message;
 
-  private Map<String,String> errors = new LinkedHashMap<>();
+  private List<ValidationException.Error> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -17,11 +18,25 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public Map<String, String> getErrors() {
+  public List<ValidationException.Error> getErrors() {
     return errors;
   }
 
-  public void setErrors(Map<String, String> errors) {
+  public void setErrors(List<ValidationException.Error> errors) {
     this.errors = errors;
+  }
+
+  public String get(String field) {
+    return errorForField(field)
+      .map(ValidationException.Error::getMessage)
+      .orElseThrow();
+  }
+  public Optional<ValidationException.Error> errorForField(String field) {
+    for (ValidationException.Error error : errors) {
+      if (field.equals(error.getField())) {
+        return Optional.of(error);
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/http-client/src/test/java/org/example/webserver/ErrorResponse.java
+++ b/http-client/src/test/java/org/example/webserver/ErrorResponse.java
@@ -8,7 +8,7 @@ public class ErrorResponse {
 
   private String message;
 
-  private List<ValidationException.Error> errors = new ArrayList<>();
+  private List<ValidationException.ViolationMessage> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -18,21 +18,21 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public List<ValidationException.Error> getErrors() {
+  public List<ValidationException.ViolationMessage> getErrors() {
     return errors;
   }
 
-  public void setErrors(List<ValidationException.Error> errors) {
+  public void setErrors(List<ValidationException.ViolationMessage> errors) {
     this.errors = errors;
   }
 
   public String get(String field) {
     return errorForField(field)
-      .map(ValidationException.Error::getMessage)
+      .map(ValidationException.ViolationMessage::getMessage)
       .orElseThrow();
   }
-  public Optional<ValidationException.Error> errorForField(String field) {
-    for (ValidationException.Error error : errors) {
+  public Optional<ValidationException.ViolationMessage> errorForField(String field) {
+    for (ValidationException.ViolationMessage error : errors) {
       if (field.equals(error.getField())) {
         return Optional.of(error);
       }

--- a/http-hibernate-validator/pom.xml
+++ b/http-hibernate-validator/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-http-hibernate-validator</artifactId>
-  <version>3.5-RC2</version>
+  <version>3.5-RC3</version>
 
   <parent>
     <groupId>org.avaje</groupId>

--- a/http-hibernate-validator/pom.xml
+++ b/http-hibernate-validator/pom.xml
@@ -5,12 +5,12 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-http-hibernate-validator</artifactId>
-  <version>3.3</version>
+  <version>3.5-RC1</version>
 
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>3.9</version>
+    <version>3.10</version>
     <relativePath/>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.45-SNAPSHOT</version>
+      <version>2.0-RC1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/http-hibernate-validator/pom.xml
+++ b/http-hibernate-validator/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-http-hibernate-validator</artifactId>
-  <version>3.5-RC1</version>
+  <version>3.5-RC2</version>
 
   <parent>
     <groupId>org.avaje</groupId>

--- a/http-hibernate-validator/src/main/java/io/avaje/http/hibernate/validator/BeanValidator.java
+++ b/http-hibernate-validator/src/main/java/io/avaje/http/hibernate/validator/BeanValidator.java
@@ -3,7 +3,7 @@ package io.avaje.http.hibernate.validator;
 import java.util.*;
 
 import io.avaje.http.api.ValidationException;
-import io.avaje.http.api.ValidationException.ViolationMessage;
+import io.avaje.http.api.ValidationException.Violation;
 import io.avaje.http.api.Validator;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -23,13 +23,13 @@ public class BeanValidator implements Validator {
   }
 
   private void throwExceptionWith(Set<ConstraintViolation<Object>> violations) {
-    List<ViolationMessage> errors = new ArrayList<>();
+    List<Violation> errors = new ArrayList<>();
 
     for (final ConstraintViolation<?> violation : violations) {
       final var path = violation.getPropertyPath().toString();
       final var field = pathToField(path);
       final var message = violation.getMessage();
-      errors.add(new ViolationMessage(path, field, message));
+      errors.add(new Violation(path, field, message));
     }
 
     var cause = new ConstraintViolationException(violations);

--- a/http-hibernate-validator/src/main/java/io/avaje/http/hibernate/validator/BeanValidator.java
+++ b/http-hibernate-validator/src/main/java/io/avaje/http/hibernate/validator/BeanValidator.java
@@ -3,6 +3,7 @@ package io.avaje.http.hibernate.validator;
 import java.util.*;
 
 import io.avaje.http.api.ValidationException;
+import io.avaje.http.api.ValidationException.ViolationMessage;
 import io.avaje.http.api.Validator;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -22,13 +23,13 @@ public class BeanValidator implements Validator {
   }
 
   private void throwExceptionWith(Set<ConstraintViolation<Object>> violations) {
-    List<ValidationException.Error> errors = new ArrayList<>();
+    List<ViolationMessage> errors = new ArrayList<>();
 
     for (final ConstraintViolation<?> violation : violations) {
       final var path = violation.getPropertyPath().toString();
       final var field = pathToField(path);
       final var message = violation.getMessage();
-      errors.add(new ValidationException.Error(path, field, message));
+      errors.add(new ViolationMessage(path, field, message));
     }
 
     var cause = new ConstraintViolationException(violations);

--- a/tests/test-javalin-jsonb/pom.xml
+++ b/tests/test-javalin-jsonb/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.3</version>
+      <version>3.5-RC1</version>
     </dependency>
 
     <dependency>

--- a/tests/test-javalin-jsonb/pom.xml
+++ b/tests/test-javalin-jsonb/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.5-RC1</version>
+      <version>3.5-RC2</version>
     </dependency>
 
     <dependency>

--- a/tests/test-javalin-jsonb/pom.xml
+++ b/tests/test-javalin-jsonb/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.5-RC2</version>
+      <version>3.5-RC3</version>
     </dependency>
 
     <dependency>

--- a/tests/test-javalin-jsonb/src/test/java/org/example/myapp/ErrorResponse.java
+++ b/tests/test-javalin-jsonb/src/test/java/org/example/myapp/ErrorResponse.java
@@ -8,7 +8,7 @@ public class ErrorResponse {
 
   private String message;
 
-  private List<ValidationException.ViolationMessage> errors = new ArrayList<>();
+  private List<ValidationException.Violation> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -18,21 +18,21 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public List<ValidationException.ViolationMessage> getErrors() {
+  public List<ValidationException.Violation> getErrors() {
     return errors;
   }
 
-  public void setErrors(List<ValidationException.ViolationMessage> errors) {
+  public void setErrors(List<ValidationException.Violation> errors) {
     this.errors = errors;
   }
 
   public String get(String field) {
     return errorForField(field)
-      .map(ValidationException.ViolationMessage::getMessage)
+      .map(ValidationException.Violation::getMessage)
       .orElseThrow();
   }
-  public Optional<ValidationException.ViolationMessage> errorForField(String field) {
-    for (ValidationException.ViolationMessage error : errors) {
+  public Optional<ValidationException.Violation> errorForField(String field) {
+    for (ValidationException.Violation error : errors) {
       if (field.equals(error.getField())) {
         return Optional.of(error);
       }

--- a/tests/test-javalin-jsonb/src/test/java/org/example/myapp/ErrorResponse.java
+++ b/tests/test-javalin-jsonb/src/test/java/org/example/myapp/ErrorResponse.java
@@ -1,13 +1,14 @@
 package org.example.myapp;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import io.avaje.http.api.ValidationException;
+
+import java.util.*;
 
 public class ErrorResponse {
 
   private String message;
 
-  private Map<String,String> errors = new LinkedHashMap<>();
+  private List<ValidationException.Error> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -17,11 +18,25 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public Map<String, String> getErrors() {
+  public List<ValidationException.Error> getErrors() {
     return errors;
   }
 
-  public void setErrors(Map<String, String> errors) {
+  public void setErrors(List<ValidationException.Error> errors) {
     this.errors = errors;
+  }
+
+  public String get(String field) {
+    return errorForField(field)
+      .map(ValidationException.Error::getMessage)
+      .orElseThrow();
+  }
+  public Optional<ValidationException.Error> errorForField(String field) {
+    for (ValidationException.Error error : errors) {
+      if (field.equals(error.getField())) {
+        return Optional.of(error);
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/tests/test-javalin-jsonb/src/test/java/org/example/myapp/ErrorResponse.java
+++ b/tests/test-javalin-jsonb/src/test/java/org/example/myapp/ErrorResponse.java
@@ -8,7 +8,7 @@ public class ErrorResponse {
 
   private String message;
 
-  private List<ValidationException.Error> errors = new ArrayList<>();
+  private List<ValidationException.ViolationMessage> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -18,21 +18,21 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public List<ValidationException.Error> getErrors() {
+  public List<ValidationException.ViolationMessage> getErrors() {
     return errors;
   }
 
-  public void setErrors(List<ValidationException.Error> errors) {
+  public void setErrors(List<ValidationException.ViolationMessage> errors) {
     this.errors = errors;
   }
 
   public String get(String field) {
     return errorForField(field)
-      .map(ValidationException.Error::getMessage)
+      .map(ValidationException.ViolationMessage::getMessage)
       .orElseThrow();
   }
-  public Optional<ValidationException.Error> errorForField(String field) {
-    for (ValidationException.Error error : errors) {
+  public Optional<ValidationException.ViolationMessage> errorForField(String field) {
+    for (ValidationException.ViolationMessage error : errors) {
       if (field.equals(error.getField())) {
         return Optional.of(error);
       }

--- a/tests/test-javalin-jsonb/src/test/java/org/example/myapp/HelloControllerTest.java
+++ b/tests/test-javalin-jsonb/src/test/java/org/example/myapp/HelloControllerTest.java
@@ -208,9 +208,8 @@ class HelloControllerTest extends BaseWebTest {
 
     assertNotNull(res);
     assertThat(res.getMessage()).contains("failed validation");
-    final Map<String, String> errors = res.getErrors();
-    assertThat(errors.get("url")).isEqualTo("must be a valid URL");
-    assertThat(errors.get("name")).isEqualTo("must not be null");
+    assertThat(res.get("url")).isEqualTo("must be a valid URL");
+    assertThat(res.get("name")).isEqualTo("must not be null");
 
     try {
       client.request()
@@ -228,11 +227,8 @@ class HelloControllerTest extends BaseWebTest {
       assertEquals(422, httpResponse.statusCode());
 
       final ErrorResponse errorResponse = e.bean(ErrorResponse.class);
-
-      final Map<String, String> errorMap = errorResponse.getErrors();
-      assertThat(errorMap.get("url")).isEqualTo("must be a valid URL");
-      assertThat(errorMap.get("name")).isEqualTo("must not be null");
-
+      assertThat(errorResponse.get("url")).isEqualTo("must be a valid URL");
+      assertThat(errorResponse.get("name")).isEqualTo("must not be null");
     }
   }
 

--- a/tests/test-javalin/pom.xml
+++ b/tests/test-javalin/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.3</version>
+      <version>3.5-RC1</version>
     </dependency>
 
     <dependency>

--- a/tests/test-javalin/pom.xml
+++ b/tests/test-javalin/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.5-RC1</version>
+      <version>3.5-RC2</version>
     </dependency>
 
     <dependency>

--- a/tests/test-javalin/pom.xml
+++ b/tests/test-javalin/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.5-RC2</version>
+      <version>3.5-RC3</version>
     </dependency>
 
     <dependency>

--- a/tests/test-javalin/src/test/java/org/example/myapp/ErrorResponse.java
+++ b/tests/test-javalin/src/test/java/org/example/myapp/ErrorResponse.java
@@ -8,7 +8,7 @@ public class ErrorResponse {
 
   private String message;
 
-  private List<ValidationException.ViolationMessage> errors = new ArrayList<>();
+  private List<ValidationException.Violation> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -18,21 +18,21 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public List<ValidationException.ViolationMessage> getErrors() {
+  public List<ValidationException.Violation> getErrors() {
     return errors;
   }
 
-  public void setErrors(List<ValidationException.ViolationMessage> errors) {
+  public void setErrors(List<ValidationException.Violation> errors) {
     this.errors = errors;
   }
 
   public String get(String field) {
     return errorForField(field)
-      .map(ValidationException.ViolationMessage::getMessage)
+      .map(ValidationException.Violation::getMessage)
       .orElseThrow();
   }
-  public Optional<ValidationException.ViolationMessage> errorForField(String field) {
-    for (ValidationException.ViolationMessage error : errors) {
+  public Optional<ValidationException.Violation> errorForField(String field) {
+    for (ValidationException.Violation error : errors) {
       if (field.equals(error.getField())) {
         return Optional.of(error);
       }

--- a/tests/test-javalin/src/test/java/org/example/myapp/ErrorResponse.java
+++ b/tests/test-javalin/src/test/java/org/example/myapp/ErrorResponse.java
@@ -1,13 +1,14 @@
 package org.example.myapp;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import io.avaje.http.api.ValidationException;
+
+import java.util.*;
 
 public class ErrorResponse {
 
   private String message;
 
-  private Map<String,String> errors = new LinkedHashMap<>();
+  private List<ValidationException.Error> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -17,11 +18,25 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public Map<String, String> getErrors() {
+  public List<ValidationException.Error> getErrors() {
     return errors;
   }
 
-  public void setErrors(Map<String, String> errors) {
+  public void setErrors(List<ValidationException.Error> errors) {
     this.errors = errors;
+  }
+
+  public String get(String field) {
+    return errorForField(field)
+      .map(ValidationException.Error::getMessage)
+      .orElseThrow();
+  }
+  public Optional<ValidationException.Error> errorForField(String field) {
+    for (ValidationException.Error error : errors) {
+      if (field.equals(error.getField())) {
+        return Optional.of(error);
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/tests/test-javalin/src/test/java/org/example/myapp/ErrorResponse.java
+++ b/tests/test-javalin/src/test/java/org/example/myapp/ErrorResponse.java
@@ -8,7 +8,7 @@ public class ErrorResponse {
 
   private String message;
 
-  private List<ValidationException.Error> errors = new ArrayList<>();
+  private List<ValidationException.ViolationMessage> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -18,21 +18,21 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public List<ValidationException.Error> getErrors() {
+  public List<ValidationException.ViolationMessage> getErrors() {
     return errors;
   }
 
-  public void setErrors(List<ValidationException.Error> errors) {
+  public void setErrors(List<ValidationException.ViolationMessage> errors) {
     this.errors = errors;
   }
 
   public String get(String field) {
     return errorForField(field)
-      .map(ValidationException.Error::getMessage)
+      .map(ValidationException.ViolationMessage::getMessage)
       .orElseThrow();
   }
-  public Optional<ValidationException.Error> errorForField(String field) {
-    for (ValidationException.Error error : errors) {
+  public Optional<ValidationException.ViolationMessage> errorForField(String field) {
+    for (ValidationException.ViolationMessage error : errors) {
       if (field.equals(error.getField())) {
         return Optional.of(error);
       }

--- a/tests/test-javalin/src/test/java/org/example/myapp/HelloControllerTest.java
+++ b/tests/test-javalin/src/test/java/org/example/myapp/HelloControllerTest.java
@@ -210,9 +210,8 @@ class HelloControllerTest extends BaseWebTest {
 
     assertNotNull(res);
     assertThat(res.getMessage()).contains("failed validation");
-    final Map<String, String> errors = res.getErrors();
-    assertThat(errors.get("url")).isEqualTo("must be a valid URL");
-    assertThat(errors.get("name")).isEqualTo("must not be null");
+    assertThat(res.get("url")).isEqualTo("must be a valid URL");
+    assertThat(res.get("name")).isEqualTo("must not be null");
 
     try {
       client.request()
@@ -230,11 +229,8 @@ class HelloControllerTest extends BaseWebTest {
       assertEquals(422, httpResponse.statusCode());
 
       final ErrorResponse errorResponse = e.bean(ErrorResponse.class);
-
-      final Map<String, String> errorMap = errorResponse.getErrors();
-      assertThat(errorMap.get("url")).isEqualTo("must be a valid URL");
-      assertThat(errorMap.get("name")).isEqualTo("must not be null");
-
+      assertThat(errorResponse.get("url")).isEqualTo("must be a valid URL");
+      assertThat(errorResponse.get("name")).isEqualTo("must not be null");
     }
   }
 

--- a/tests/test-jex/pom.xml
+++ b/tests/test-jex/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.5-RC1</version>
+      <version>3.5-RC2</version>
     </dependency>
 
     <dependency>

--- a/tests/test-jex/pom.xml
+++ b/tests/test-jex/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.3</version>
+      <version>3.5-RC1</version>
     </dependency>
 
     <dependency>

--- a/tests/test-jex/pom.xml
+++ b/tests/test-jex/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-hibernate-validator</artifactId>
-      <version>3.5-RC2</version>
+      <version>3.5-RC3</version>
     </dependency>
 
     <dependency>

--- a/tests/test-jex/src/test/java/org/example/web/ErrorResponse.java
+++ b/tests/test-jex/src/test/java/org/example/web/ErrorResponse.java
@@ -8,7 +8,7 @@ public class ErrorResponse {
 
   private String message;
 
-  private List<ValidationException.ViolationMessage> errors = new ArrayList<>();
+  private List<ValidationException.Violation> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -18,21 +18,21 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public List<ValidationException.ViolationMessage> getErrors() {
+  public List<ValidationException.Violation> getErrors() {
     return errors;
   }
 
-  public void setErrors(List<ValidationException.ViolationMessage> errors) {
+  public void setErrors(List<ValidationException.Violation> errors) {
     this.errors = errors;
   }
 
   public String get(String field) {
     return errorForField(field)
-      .map(ValidationException.ViolationMessage::getMessage)
+      .map(ValidationException.Violation::getMessage)
       .orElseThrow();
   }
-  public Optional<ValidationException.ViolationMessage> errorForField(String field) {
-    for (ValidationException.ViolationMessage error : errors) {
+  public Optional<ValidationException.Violation> errorForField(String field) {
+    for (ValidationException.Violation error : errors) {
       if (field.equals(error.getField())) {
         return Optional.of(error);
       }

--- a/tests/test-jex/src/test/java/org/example/web/ErrorResponse.java
+++ b/tests/test-jex/src/test/java/org/example/web/ErrorResponse.java
@@ -8,7 +8,7 @@ public class ErrorResponse {
 
   private String message;
 
-  private List<ValidationException.Error> errors = new ArrayList<>();
+  private List<ValidationException.ViolationMessage> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -18,21 +18,21 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public List<ValidationException.Error> getErrors() {
+  public List<ValidationException.ViolationMessage> getErrors() {
     return errors;
   }
 
-  public void setErrors(List<ValidationException.Error> errors) {
+  public void setErrors(List<ValidationException.ViolationMessage> errors) {
     this.errors = errors;
   }
 
   public String get(String field) {
     return errorForField(field)
-      .map(ValidationException.Error::getMessage)
+      .map(ValidationException.ViolationMessage::getMessage)
       .orElseThrow();
   }
-  public Optional<ValidationException.Error> errorForField(String field) {
-    for (ValidationException.Error error : errors) {
+  public Optional<ValidationException.ViolationMessage> errorForField(String field) {
+    for (ValidationException.ViolationMessage error : errors) {
       if (field.equals(error.getField())) {
         return Optional.of(error);
       }

--- a/tests/test-jex/src/test/java/org/example/web/ErrorResponse.java
+++ b/tests/test-jex/src/test/java/org/example/web/ErrorResponse.java
@@ -1,13 +1,14 @@
 package org.example.web;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import io.avaje.http.api.ValidationException;
+
+import java.util.*;
 
 public class ErrorResponse {
 
   private String message;
 
-  private Map<String,String> errors = new LinkedHashMap<>();
+  private List<ValidationException.Error> errors = new ArrayList<>();
 
   public String getMessage() {
     return message;
@@ -17,11 +18,25 @@ public class ErrorResponse {
     this.message = message;
   }
 
-  public Map<String, String> getErrors() {
+  public List<ValidationException.Error> getErrors() {
     return errors;
   }
 
-  public void setErrors(Map<String, String> errors) {
+  public void setErrors(List<ValidationException.Error> errors) {
     this.errors = errors;
+  }
+
+  public String get(String field) {
+    return errorForField(field)
+      .map(ValidationException.Error::getMessage)
+      .orElseThrow();
+  }
+  public Optional<ValidationException.Error> errorForField(String field) {
+    for (ValidationException.Error error : errors) {
+      if (field.equals(error.getField())) {
+        return Optional.of(error);
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/tests/test-jex/src/test/java/org/example/web/HelloControllerTest.java
+++ b/tests/test-jex/src/test/java/org/example/web/HelloControllerTest.java
@@ -63,7 +63,7 @@ class HelloControllerTest extends BaseWebTest {
       .PUT().asString();
 
     assertThat(hres.statusCode()).isEqualTo(422);
-    assertThat(hres.body()).contains("{\"name\":\"must not be null\"}");
+    assertThat(hres.body()).contains("{\"path\":\"name\",\"field\":\"name\",\"message\":\"must not be null\"}");
   }
 
   @Test
@@ -79,6 +79,6 @@ class HelloControllerTest extends BaseWebTest {
     assertThat(ex.statusCode()).isEqualTo(422);
 
     final ErrorResponse errBean = ex.bean(ErrorResponse.class);
-    assertThat(errBean.getErrors().get("name")).isEqualTo("must not be null");
+    assertThat(errBean.get("name")).isEqualTo("must not be null");
   }
 }


### PR DESCRIPTION
This is effectively an API breaking change from Map -> List + explicit type

The ValidationException.Error type is fairly opinionated. If that doesn't match application requirements the error handler needs to obtain the cause and pull the constraint violation errors from that to build its error response payload message