### PR TITLE
[http-client] Generate VarArgs Correctly

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -4,6 +4,8 @@ import static io.avaje.http.generator.core.ProcessingContext.*;
 import io.avaje.http.generator.core.*;
 
 import javax.lang.model.element.TypeElement;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,11 +54,13 @@ class ClientMethodWriter {
     AnnotationUtil.writeAnnotations(writer, method.element());
     writer.append("  public %s%s %s(", methodGenericParams, returnType.shortType(), method.simpleName());
     int count = 0;
-    for (MethodParam param : method.params()) {
+    List<MethodParam> params = method.params();
+    for (int i = 0; i < params.size(); i++) {
+      MethodParam param = params.get(i);
       if (count++ > 0) {
         writer.append(", ");
       }
-      final var isVarArg = Util.isVarArg(param.element());
+      final var isVarArg = Util.isVarArg(param.element(), i);
 
       final var paramType =
           "java.util.function.Supplier<?extendsjava.io.InputStream>".equals(param.utype().full())

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -56,11 +56,16 @@ class ClientMethodWriter {
       if (count++ > 0) {
         writer.append(", ");
       }
-      var paramType =
+      final var isVarArg = Util.isVarArg(param.element());
+
+      final var paramType =
           "java.util.function.Supplier<?extendsjava.io.InputStream>".equals(param.utype().full())
               ? "Supplier<? extends InputStream>"
               : param.utype().shortType();
-      writer.append(paramType).append(" ");
+
+      final var finalType =
+          isVarArg ? paramType.substring(0, paramType.length() - 2) + "..." : paramType;
+      writer.append(finalType).append(" ");
       writer.append(param.name());
     }
     writer.append(") {").eol();

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/UserClient.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/UserClient.java
@@ -3,6 +3,7 @@ package io.avaje.http.generator.client.clients;
 import io.avaje.http.api.BodyString;
 import io.avaje.http.api.Client;
 import io.avaje.http.api.Get;
+import io.avaje.http.api.Header;
 import io.avaje.http.api.Post;
 
 @Client(generate = false)
@@ -13,6 +14,9 @@ public interface UserClient {
 
   @Post("/body")
   String bodies(Body... bodies);
+
+  @Post("/body2")
+  String bodies2(@Header String head, Body... bodies);
 
   @Get("/users/{userId}")
   String getUserById(String userId);

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodParam.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodParam.java
@@ -2,6 +2,7 @@ package io.avaje.http.generator.core;
 
 import static io.avaje.http.generator.core.ProcessingContext.asElement;
 
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.VariableElement;
 
@@ -82,6 +83,10 @@ public class MethodParam {
 
   public void setResponseHandler() {
     elementParam.setResponseHandler();
+  }
+
+  public VariableElement element() {
+    return (VariableElement) elementParam.element();
   }
 
   @Override

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
@@ -236,7 +236,7 @@ public class Util {
       var params = matcher.group(1);
 
       return Arrays.stream(params.split(","))
-          .filter(s -> s.contains(typeString))
+          .filter(s -> s.replace("[]", "").contains(typeString))
           .anyMatch(s -> s.endsWith("..."));
     }
     return false;

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
@@ -9,6 +9,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleAnnotationValueVisitor8;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -225,6 +226,22 @@ public class Util {
     return parse(returnType.toString());
   }
 
+  public static boolean isVarArg(VariableElement element) {
+    var methodString = Util.trimAnnotations(element.getEnclosingElement().toString());
+    var typeString = Util.trimAnnotations(element.asType().toString()).replace("[]", "");
+    Pattern pattern = Pattern.compile("\\((.*?)\\)");
+    Matcher matcher = pattern.matcher(methodString);
+
+    if (matcher.find()) {
+      var params = matcher.group(1);
+
+      return Arrays.stream(params.split(","))
+          .filter(s -> s.contains(typeString))
+          .anyMatch(s -> s.endsWith("..."));
+    }
+    return false;
+  }
+  
   private static class RoleReader extends SimpleAnnotationValueVisitor8<List<String>, Object> {
 
     private final List<String> fullRoles = new ArrayList<>();

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
@@ -9,7 +9,6 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleAnnotationValueVisitor8;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -22,6 +21,7 @@ public class Util {
   // comma not in quotes
   private static final Pattern COMMA_PATTERN =
       Pattern.compile(", (?=(?:[^\\\"]*\\\"[^\\\"]*\\\")*[^\\\"]*$)");
+  private static final Pattern PARENTHESIS_CONTENT = Pattern.compile("\\((.*?)\\)");
 
   /**
    * Parse the raw type potentially handling generic parameters.
@@ -226,22 +226,19 @@ public class Util {
     return parse(returnType.toString());
   }
 
-  public static boolean isVarArg(VariableElement element) {
+  public static boolean isVarArg(VariableElement element, int order) {
     var methodString = Util.trimAnnotations(element.getEnclosingElement().toString());
     var typeString = Util.trimAnnotations(element.asType().toString()).replace("[]", "");
-    Pattern pattern = Pattern.compile("\\((.*?)\\)");
-    Matcher matcher = pattern.matcher(methodString);
+    Matcher matcher = PARENTHESIS_CONTENT.matcher(methodString);
 
     if (matcher.find()) {
-      var params = matcher.group(1);
+      var param = matcher.group(1).split(",")[order];
 
-      return Arrays.stream(params.split(","))
-          .filter(s -> s.replace("[]", "").contains(typeString))
-          .anyMatch(s -> s.endsWith("..."));
+      return param.replace("[]", "").contains(typeString) && param.endsWith("...");
     }
     return false;
   }
-  
+
   private static class RoleReader extends SimpleAnnotationValueVisitor8<List<String>, Object> {
 
     private final List<String> fullRoles = new ArrayList<>();

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
@@ -226,13 +226,13 @@ public class Util {
     return parse(returnType.toString());
   }
 
-  public static boolean isVarArg(VariableElement element, int order) {
+  public static boolean isVarArg(VariableElement element, int position) {
     var methodString = Util.trimAnnotations(element.getEnclosingElement().toString());
     var typeString = Util.trimAnnotations(element.asType().toString()).replace("[]", "");
     Matcher matcher = PARENTHESIS_CONTENT.matcher(methodString);
 
     if (matcher.find()) {
-      var param = matcher.group(1).split(",")[order];
+      var param = matcher.group(1).split(",")[position];
 
       return param.replace("[]", "").contains(typeString) && param.endsWith("...");
     }

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerMethodWriter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/ControllerMethodWriter.java
@@ -129,12 +129,12 @@ class ControllerMethodWriter {
     if (instrumentContext) {
       writer.append("      if (ctx.resultInputStream() != null || ctx.res().isCommitted()) return;").eol();
     }
-
     // Support for CompletableFuture's.
     final UType type = UType.parse(method.returnType());
     if ("java.util.concurrent.CompletableFuture".equals(type.mainType())) {
       if (!type.isGeneric()) {
-        throw new IllegalStateException(
+        logError(
+            method.element(),
             "CompletableFuture must be generic type (e.g. CompletableFuture<String>, CompletableFuture<Void>).");
       }
 


### PR DESCRIPTION
Adds a way to detect if an element is a varArg, and generates the implementation with a vararg param instead of an array.