### PR TITLE
Move javalin annotations out of Generator

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/javalin/After.java
+++ b/http-api/src/main/java/io/avaje/http/api/javalin/After.java
@@ -1,4 +1,4 @@
-package io.avaje.http.javalin;
+package io.avaje.http.api.javalin;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.SOURCE;

--- a/http-api/src/main/java/io/avaje/http/api/javalin/Before.java
+++ b/http-api/src/main/java/io/avaje/http/api/javalin/Before.java
@@ -1,4 +1,4 @@
-package io.avaje.http.javalin;
+package io.avaje.http.api.javalin;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.SOURCE;

--- a/http-api/src/main/java/module-info.java
+++ b/http-api/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module io.avaje.http.api {
 
 	exports io.avaje.http.api;
+	exports io.avaje.http.api.javalin;
 	exports io.avaje.http.api.context;
 	exports io.avaje.http.api.spi;
 }

--- a/http-generator-javalin/pom.xml
+++ b/http-generator-javalin/pom.xml
@@ -23,6 +23,13 @@
       <version>${avaje.prisms.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-http-api</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
 
   </dependencies>
 

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinProcessor.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinProcessor.java
@@ -2,12 +2,12 @@ package io.avaje.http.generator.javalin;
 
 import java.io.IOException;
 
+import io.avaje.http.api.javalin.After;
+import io.avaje.http.api.javalin.Before;
 import io.avaje.http.generator.core.BaseProcessor;
 import io.avaje.http.generator.core.ControllerReader;
 import io.avaje.http.generator.core.PlatformAdapter;
 import io.avaje.http.generator.core.ProcessingContext;
-import io.avaje.http.javalin.After;
-import io.avaje.http.javalin.Before;
 import io.avaje.prism.GeneratePrism;
 
 @GeneratePrism(value = After.class, superClass = AbstractCustomMethodPrism.class)

--- a/http-generator-javalin/src/main/java/module-info.java
+++ b/http-generator-javalin/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module io.avaje.http.javalin.generator {
   requires java.sql;
 
   // SHADED: All content after this line will be removed at package time
-  requires transitive io.avaje.http.generator.core;
+  requires io.avaje.http.generator.core;
+  requires io.avaje.http.api;
   requires static io.avaje.prism;
 }

--- a/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController2.java
+++ b/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/TestController2.java
@@ -8,8 +8,8 @@ import java.util.Set;
 import org.example.myapp.web.ServerType;
 
 import io.avaje.http.api.*;
-import io.avaje.http.javalin.After;
-import io.avaje.http.javalin.Before;
+import io.avaje.http.api.javalin.After;
+import io.avaje.http.api.javalin.Before;
 import io.javalin.http.Context;
 
 @Path("test/")


### PR DESCRIPTION
As I discovered earlier, it seems annotations and their processors can't be in the same module if you want it to work on the module-path automatically.