### PR TITLE
[http client] HttpException internally read the response body once

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/HttpException.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpException.java
@@ -46,6 +46,7 @@ public class HttpException extends RuntimeException {
   private final boolean responseAsBytes;
   private final DHttpClientContext context;
   private final HttpResponse<?> httpResponse;
+  private BodyContent body;
 
   /**
    * Create with status code and message.
@@ -96,6 +97,13 @@ public class HttpException extends RuntimeException {
     this.responseAsBytes = true;
   }
 
+  private BodyContent readBody() {
+    if (body == null) {
+      body = context.readErrorContent(responseAsBytes, httpResponse);
+    }
+    return body;
+  }
+
   /**
    * Return the response body content as a bean, or else null if body content doesn't exist.
    *
@@ -106,8 +114,7 @@ public class HttpException extends RuntimeException {
     if (httpResponse == null) {
       return null;
     }
-    final BodyContent body = context.readErrorContent(responseAsBytes, httpResponse);
-    return context.readBean(cls, body);
+    return context.readBean(cls, readBody());
   }
 
   /**
@@ -117,8 +124,7 @@ public class HttpException extends RuntimeException {
     if (httpResponse == null) {
       return null;
     }
-    final BodyContent body = context.readErrorContent(responseAsBytes, httpResponse);
-    return new String(body.content(), StandardCharsets.UTF_8);
+    return new String(readBody().content(), StandardCharsets.UTF_8);
   }
 
   /**
@@ -128,8 +134,7 @@ public class HttpException extends RuntimeException {
     if (httpResponse == null) {
       return null;
     }
-    final BodyContent body = context.readErrorContent(responseAsBytes, httpResponse);
-    return body.content();
+    return readBody().content();
   }
 
   /**

--- a/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -517,6 +517,9 @@ class HelloControllerTest extends BaseWebTest {
     // convert json error response body to a bean
     final ErrorResponse errorResponse = httpException.bean(ErrorResponse.class);
     assertThat(errorResponse.get("email")).isEqualTo("must be a well-formed email address");
+
+    String responseBodyString = httpException.bodyAsString();
+    assertThat(responseBodyString).startsWith("{\"message\":\"Request failed validation\",\"errors\":");
   }
 
   @Test
@@ -1249,6 +1252,7 @@ class HelloControllerTest extends BaseWebTest {
 
       final byte[] rawBytes = e.bodyAsBytes();
       assertThat(rawBytes).isNotNull();
+      assertThat(new String(rawBytes, 0, rawBytes.length, StandardCharsets.UTF_8)).contains("must be a valid URL");
     }
   }
 


### PR DESCRIPTION
If the response is read multiple times (say as String + decoded to a bean) then only read the response body once