### PR TITLE
[http client] HttpException add isPlainText() and contentType()

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/HttpException.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpException.java
@@ -2,6 +2,7 @@ package io.avaje.http.client;
 
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 /**
  * HTTP Exception with support for converting the error response body into a bean.
@@ -149,6 +150,20 @@ public class HttpException extends RuntimeException {
    */
   public HttpResponse<?> httpResponse() {
     return httpResponse;
+  }
+
+  /**
+   * Return the response Content-Type header.
+   */
+  public Optional<String> contentType() {
+    return httpResponse.headers().firstValue("Content-Type");
+  }
+
+  /**
+   * Return true if the Content-Type is text/plain.
+   */
+  public boolean isPlainText() {
+    return "text/plain".equals(contentType().orElse(null));
   }
 
 }

--- a/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -286,6 +286,12 @@ class HelloControllerTest extends BaseWebTest {
     assertThat(metrics.errorCount()).isEqualTo(1);
     assertThat(metrics.responseBytes()).isEqualTo(0);
     assertThat(metrics.totalMicros()).isGreaterThan(0);
+
+    assertThat(httpException.bodyAsString()).isEqualTo("Not Found");
+    assertThat(httpException.isPlainText()).isTrue();
+    assertThat(httpException.contentType())
+      .isPresent()
+      .get().isEqualTo("text/plain");
   }
 
   @Test
@@ -799,6 +805,20 @@ class HelloControllerTest extends BaseWebTest {
   }
 
   @Test
+  void get_bean_404() {
+    try {
+      clientContext.request()
+        .path("does-not-exist")
+        .GET()
+        .bean(HelloDto.class);
+    } catch (HttpException e) {
+      assertThat(e.statusCode()).isEqualTo(404);
+      assertThat(e.contentType()).isPresent().get().isEqualTo("text/plain");
+      assertThat(e.bodyAsString()).isEqualTo("Not Found");
+    }
+  }
+
+  @Test
   void get_withPathParamAndQueryParam_returningBean() {
 
     final HelloDto dto = clientContext.request()
@@ -1242,6 +1262,12 @@ class HelloControllerTest extends BaseWebTest {
       final HttpResponse<?> httpResponse = e.httpResponse();
       assertNotNull(httpResponse);
       assertEquals(422, httpResponse.statusCode());
+
+      assertThat(e.contentType())
+        .isPresent()
+        .get().isEqualTo("application/json");
+
+      assertThat(e.isPlainText()).isFalse();
 
       final ErrorResponse errorResponse = e.bean(ErrorResponse.class);
       assertThat(errorResponse.get("url")).isEqualTo("must be a valid URL");

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/MappedException.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/MappedException.java
@@ -4,5 +4,35 @@ import io.avaje.http.client.HttpException;
 
 public class MappedException extends RuntimeException {
 
-  public MappedException(HttpException e) {}
+  private final int statusCode;
+  private String responseMessage;
+  private MyJsonErrorPayload myPayload;
+
+  public MappedException(HttpException httpException) {
+    super("Error response with statusCode: " + httpException.statusCode());
+    this.statusCode = httpException.statusCode();
+    if (httpException.isPlainText()) {
+      this.responseMessage = httpException.bodyAsString();
+    } else {
+      this.myPayload = httpException.bean(MyJsonErrorPayload.class);
+    }
+    addSuppressed(httpException);
+  }
+
+  public int statusCode() {
+    return statusCode;
+  }
+
+  public String responseMessage() {
+    return responseMessage;
+  }
+
+  public MyJsonErrorPayload myPayload() {
+    return myPayload;
+  }
+
+  // @Json
+  static class MyJsonErrorPayload {
+    // fields
+  }
 }


### PR DESCRIPTION
Helper methods to make it easier for use cases that need logic in reading the HttpException that could be text or json etc