### PR TITLE
[http client] Generation for @Client.Import when argument names lost

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientPlatformAdapter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientPlatformAdapter.java
@@ -45,8 +45,7 @@ class ClientPlatformAdapter implements PlatformAdapter {
   public void writeReadParameter(Append writer, ParamType paramType, String paramName) {}
 
   @Override
-  public void writeReadParameter(
-      Append writer, ParamType paramType, String paramName, String paramDefault) {}
+  public void writeReadParameter(Append writer, ParamType paramType, String paramName, String paramDefault) {}
 
   @Override
   public void writeAcceptLanguage(Append writer) {}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodParam.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodParam.java
@@ -2,7 +2,6 @@ package io.avaje.http.generator.core;
 
 import static io.avaje.http.generator.core.ProcessingContext.asElement;
 
-import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.VariableElement;
 
@@ -67,6 +66,18 @@ public class MethodParam {
 
   public String name() {
     return elementParam.varName();
+  }
+
+  public boolean overrideVarNameError() {
+    return elementParam.overrideVarNameError();
+  }
+
+  public void overrideVarName(String name, ParamType paramType) {
+    elementParam.overrideVarName(name, paramType);
+  }
+
+  public void overrideVarName(int position) {
+    elementParam.overrideVarName(position);
   }
 
   public String paramName() {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/PlatformAdapter.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/PlatformAdapter.java
@@ -35,8 +35,7 @@ public interface PlatformAdapter {
 
   void writeReadParameter(Append writer, ParamType paramType, String paramName);
 
-  void writeReadParameter(
-      Append writer, ParamType paramType, String paramName, String paramDefault);
+  void writeReadParameter(Append writer, ParamType paramType, String paramName, String paramDefault);
 
   void writeAcceptLanguage(Append writer);
 

--- a/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/NimaPlatformAdapter.java
+++ b/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/NimaPlatformAdapter.java
@@ -83,8 +83,7 @@ class NimaPlatformAdapter implements PlatformAdapter {
   }
 
   @Override
-  public void writeReadParameter(
-      Append writer, ParamType paramType, String paramName, String paramDefault) {
+  public void writeReadParameter(Append writer, ParamType paramType, String paramName, String paramDefault) {
     switch (paramType) {
       case PATHPARAM -> writer.append(
           "pathParams.first(\"%s\").orElse(\"%s\")", paramName, paramDefault);

--- a/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinAdapter.java
+++ b/http-generator-javalin/src/main/java/io/avaje/http/generator/javalin/JavalinAdapter.java
@@ -77,8 +77,7 @@ class JavalinAdapter implements PlatformAdapter {
   }
 
   @Override
-  public void writeReadParameter(
-      Append writer, ParamType paramType, String paramName, String paramDefault) {
+  public void writeReadParameter(Append writer, ParamType paramType, String paramName, String paramDefault) {
     writer.append("withDefault(ctx.%s(\"%s\"), \"%s\")", paramType, paramName, paramDefault);
   }
 

--- a/tests/test-client-generation/pom.xml
+++ b/tests/test-client-generation/pom.xml
@@ -11,6 +11,8 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <surefire.useModulePath>false</surefire.useModulePath>
   </properties>
 
   <dependencies>
@@ -96,7 +98,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.11.0</version>
         <configuration>
           <annotationProcessorPaths>
             <path>

--- a/tests/test-client-generation/src/main/java/org/example/CommonApi.java
+++ b/tests/test-client-generation/src/main/java/org/example/CommonApi.java
@@ -3,6 +3,7 @@ package org.example;
 import io.avaje.http.api.Get;
 import io.avaje.http.api.Path;
 import io.avaje.http.api.Produces;
+import io.avaje.http.api.QueryParam;
 
 import java.time.LocalDate;
 
@@ -19,6 +20,6 @@ public interface CommonApi {
 
   @Produces("text/plain")
   @Get("{id}/{name}")
-  String p2(long id, String name, LocalDate after, Boolean more);
+  String p2(long id, String name, @QueryParam("after") LocalDate after, @QueryParam("more") Boolean more);
 
 }

--- a/tests/test-client-generation/src/main/java/org/example/client/package-info.java
+++ b/tests/test-client-generation/src/main/java/org/example/client/package-info.java
@@ -1,4 +1,3 @@
-@Client.Import(types = CommonApi.class)
 package org.example.client;
 
 import io.avaje.http.api.Client;

--- a/tests/test-client-generation/src/test/java/org/example/CommonApiTest.java
+++ b/tests/test-client-generation/src/test/java/org/example/CommonApiTest.java
@@ -1,5 +1,6 @@
 package org.example;
 
+import io.avaje.http.api.Client;
 import io.avaje.http.client.HttpClient;
 import io.avaje.http.client.JacksonBodyAdapter;
 import org.example.server.Main;
@@ -11,6 +12,7 @@ import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Client.Import(types = CommonApi.class)
 class CommonApiTest {
 
   static CommonApi client;


### PR DESCRIPTION
When the interface has been previously compiled then the method arg names are effectively lost - become arg0, arg1, arg2 etc. In this case the generation can get the implied arg names for path parameters from the segments but for @QueryParam and @Header parameters we now need explicitly named arguments.

This change handles the path segments and gives a reasonable error for QueryParams and Headers etc that are not explicitly named.