### PR TITLE
[http-client] Allow paths to be loaded from System Properties/Avaje Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use source code generation to adapt annotated REST controllers `@Path, @Get, @Po
 
 - Lightweight (65Kb library + generated source code)
 - Full use of Javalin or Helidon SE/Nima as desired
-- Bean Validation of request bodies supported
+- Bean Validation of request bodies supported (validation groups supported as well)
 
 ## Add dependencies
 ```xml
@@ -58,7 +58,7 @@ In JDK 22+, annotation processors are disabled by default, you will need to add 
 </plugin>
 ```
 
-## Define a Controller (These APT processors work with Java and Kotlin.)
+## Define a Controller (These APT processors work with both Java and Kotlin)
 ```java
 package org.example.hello;
 
@@ -106,7 +106,7 @@ To force the AP to generate with `@javax.inject.Singleton`(in the case where you
 
 ### Usage with Javalin
 
-The annotation processor will generate controller classes implementing the Javalin `Plugin` interface, which means we can register them with Javalin using:
+The annotation processor will generate controller classes implementing the Javalin `Plugin` interface, which we can register using:
 
 ```java
 List<Plugin> routes = ...; //retrieve using a DI framework
@@ -268,6 +268,7 @@ public class WidgetController$Route implements HttpFeature {
     var id = asInt(pathParams.first("id").get());
     var result = controller.getById(id);
     res.headers().contentType(MediaTypes.APPLICATION_JSON);
+    //jsonb has a special accommodation for helidon to improve performance
     widgetController$WidgetJsonType.toJson(result, JsonOutput.of(res));
   }
 

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/UserClient.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/UserClient.java
@@ -20,4 +20,7 @@ public interface UserClient {
 
   @Get("/users/{userId}")
   String getUserById(String userId);
+
+  @Get("${property.path}/users/{userId}")
+  String property(String userId);
 }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
@@ -23,6 +23,8 @@ public class Util {
       Pattern.compile(", (?=(?:[^\\\"]*\\\"[^\\\"]*\\\")*[^\\\"]*$)");
   private static final Pattern PARENTHESIS_CONTENT = Pattern.compile("\\((.*?)\\)");
 
+  private static final Pattern SANITIZE_PATTERN = Pattern.compile("[^a-zA-Z0-9_]|\\s");
+
   /**
    * Parse the raw type potentially handling generic parameters.
    */
@@ -46,6 +48,11 @@ public class Util {
     } else {
       return trimAnnotations(typeMirror.toString());
     }
+  }
+
+  /** Sanitize the given string such that it can be used as a method/class/field name */
+  public static String sanitizeName(String name) {
+    return SANITIZE_PATTERN.matcher(name).replaceAll("_");
   }
 
   /** Trim off annotations from the raw type if present. */
@@ -173,13 +180,11 @@ public class Util {
       if (ch == '-') {
         sb.append(ch);
         upper = true;
+      } else if (upper) {
+        sb.append(Character.toUpperCase(ch));
+        upper = false;
       } else {
-        if (upper) {
-          sb.append(Character.toUpperCase(ch));
-          upper = false;
-        } else {
-          sb.append(ch);
-        }
+        sb.append(ch);
       }
     }
     return sb.toString();


### PR DESCRIPTION
Now can dynamically determine the paths at runtime using system properties or avaje config.

With this, we can perform tomfoolery such as:

```java
@Client
public interface TitanFall {

  @Get("/${titan}/${drop.point}")
  Titan titanfall();
}
```

and the following will generate 

```java
@Generated("avaje-http-client-generator")
public class TitanFallHttpClient implements TitanFall {
  private final HttpClient client;
  public TitanFallHttpClient(HttpClient client) {
    this.client = client;
  }
                                //if available will use Config.get instead 
  private static final String DROP_POINT = System.getProperty("drop.point");
  private static final String TITAN = System.getProperty("titan");
  // GET /${titan}/${drop.point}
  @Override
  public Titan titanfall() {
    return client.request()
      .path(TITAN).path(DROP_POINT)
      .GET()
      .bean(Titan.class);
  }
}
```