### PR TITLE
[http-client] Reset base if an http scheme is detected

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/DUrlBuilder.java
+++ b/http-client/src/main/java/io/avaje/http/client/DUrlBuilder.java
@@ -22,6 +22,9 @@ final class DUrlBuilder implements UrlBuilder {
 
   @Override
   public UrlBuilder path(String path) {
+    if (path.startsWith("http") && path.contains("://")) {
+      return url(path);
+    }
     buffer.append("/").append(path);
     return this;
   }

--- a/http-client/src/main/java/io/avaje/http/client/DUrlBuilder.java
+++ b/http-client/src/main/java/io/avaje/http/client/DUrlBuilder.java
@@ -26,6 +26,10 @@ final class DUrlBuilder implements UrlBuilder {
 
   @Override
   public UrlBuilder path(String path) {
+    if (path.startsWith("http") && path.contains("://")) {
+      buffer.setLength(0);
+      return this;
+    }
     buffer.append("/").append(path);
     return this;
   }

--- a/http-client/src/main/java/io/avaje/http/client/DUrlBuilder.java
+++ b/http-client/src/main/java/io/avaje/http/client/DUrlBuilder.java
@@ -28,6 +28,7 @@ final class DUrlBuilder implements UrlBuilder {
   public UrlBuilder path(String path) {
     if (path.startsWith("http") && path.contains("://")) {
       buffer.setLength(0);
+      buffer.append(path);
       return this;
     }
     buffer.append("/").append(path);

--- a/http-client/src/main/java/io/avaje/http/client/DUrlBuilder.java
+++ b/http-client/src/main/java/io/avaje/http/client/DUrlBuilder.java
@@ -15,16 +15,17 @@ final class DUrlBuilder implements UrlBuilder {
 
   @Override
   public UrlBuilder url(String url) {
-    buffer.delete(0, buffer.length());
+
+    if (url.startsWith("http") && url.contains("://")) {
+      buffer.setLength(0);
+    }
+
     buffer.append(url);
     return this;
   }
 
   @Override
   public UrlBuilder path(String path) {
-    if (path.startsWith("http") && path.contains("://")) {
-      return url(path);
-    }
     buffer.append("/").append(path);
     return this;
   }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -382,7 +382,7 @@ private void writeEnd() {
         continue;
       }
       if (first) {
-        writer.append(".url(\"");
+        writer.append(".path(\"");
         first = false;
       }
       if (noSlash) {

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -382,7 +382,7 @@ private void writeEnd() {
         continue;
       }
       if (first) {
-        writer.append(".path(\"");
+        writer.append(".url(\"");
         first = false;
       }
       if (noSlash) {

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -396,8 +396,7 @@ private void writeEnd() {
         writer.append("\" + %s + \"", segmentPropertyMap.get(segment.name()));
 
       } else {
-        writer.append(segment.name());
-        // TODO: matrix params
+        writer.append("\" + %s + \"", segment.name());
       }
     }
     if (!segments.isEmpty()) {

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -9,6 +9,7 @@ import javax.lang.model.util.ElementFilter;
 
 import static java.util.stream.Collectors.toMap;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -366,13 +367,36 @@ private void writeEnd() {
     if (!segments.isEmpty()) {
       writer.append("      ");
     }
-    for (PathSegments.Segment segment : segments) {
+    boolean first = true;
+    Iterator<Segment> iterator = segments.iterator();
+    boolean sentinel = true;
+    boolean noSlash = false;
+    var size = segments.size();
+    while (sentinel) {
+      PathSegments.Segment segment = iterator.hasNext() ? iterator.next() : null;
+      if (segment == null) {
+        sentinel = false;
+        if (size != 0) {
+          writer.append("\")");
+        }
+        continue;
+      }
+      if (first) {
+        writer.append(".path(\"");
+        first = false;
+      }
+      if (noSlash) {
+        writer.append("/");
+      }
+      noSlash = true;
       if (segment.isLiteral()) {
-        writer.append(".path(\"").append(segment.literalSection()).append("\")");
+        writer.append(segment.literalSection());
       } else if (segment.isProperty()) {
-        writer.append(".path(").append(segmentPropertyMap.get(segment.name())).append(")");
+
+        writer.append("\" + %s + \"", segmentPropertyMap.get(segment.name()));
+
       } else {
-        writer.append(".path(").append(segment.name()).append(")");
+        writer.append(segment.name());
         // TODO: matrix params
       }
     }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -9,7 +9,6 @@ import javax.lang.model.util.ElementFilter;
 
 import static java.util.stream.Collectors.toMap;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -367,36 +366,14 @@ private void writeEnd() {
     if (!segments.isEmpty()) {
       writer.append("      ");
     }
-    boolean first = true;
-    Iterator<Segment> iterator = segments.iterator();
-    boolean sentinel = true;
-    boolean noSlash = false;
-    var size = segments.size();
-    while (sentinel) {
-      PathSegments.Segment segment = iterator.hasNext() ? iterator.next() : null;
-      if (segment == null) {
-        sentinel = false;
-        if (size != 0) {
-          writer.append("\")");
-        }
-        continue;
-      }
-      if (first) {
-        writer.append(".path(\"");
-        first = false;
-      }
-      if (noSlash) {
-        writer.append("/");
-      }
-      noSlash = true;
+    for (PathSegments.Segment segment : segments) {
       if (segment.isLiteral()) {
-        writer.append(segment.literalSection());
+        writer.append(".path(\"").append(segment.literalSection()).append("\")");
       } else if (segment.isProperty()) {
-
-        writer.append("\" + %s + \"", segmentPropertyMap.get(segment.name()));
-
+        writer.append(".path(").append(segmentPropertyMap.get(segment.name())).append(")");
       } else {
-        writer.append("\" + %s + \"", segment.name());
+        writer.append(".path(").append(segment.name()).append(")");
+        // TODO: matrix params
       }
     }
     if (!segments.isEmpty()) {

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/Titan.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/Titan.java
@@ -1,0 +1,3 @@
+package io.avaje.http.generator.client.clients;
+
+public class Titan {}

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/TitanFall.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/TitanFall.java
@@ -1,0 +1,11 @@
+package io.avaje.http.generator.client.clients;
+
+import io.avaje.http.api.Client;
+import io.avaje.http.api.Get;
+
+@Client
+public interface TitanFall {
+
+  @Get("/${titan}/${drop.point}")
+  Titan titanfall();
+}


### PR DESCRIPTION
now if we do something like:

```
  @Override
  public Titan titanfall() {
    return client.request()
      .path("https://something.com").path(DROP_POINT)
      .GET()
      .bean(Titan.class);
  }
```
the base URL  will be switched to `https://something.com`.

- `path`  will reset the URL buffer if an HTTP scheme is detected in the given string