### PR TITLE
[http-client] Generated Client Formatting

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/AnnotationUtil.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/AnnotationUtil.java
@@ -14,13 +14,17 @@ final class AnnotationUtil {
   private AnnotationUtil() {}
 
   public static void writeAnnotations(Append writer, Element element) {
+    writeAnnotations(writer, element, "");
+  }
+
+  public static void writeAnnotations(Append writer, Element element, String indent) {
     for (final AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
       final var type = UType.parse(annotationMirror.getAnnotationType().asElement().asType());
       if (type.mainType().startsWith("io.avaje.http") || type.mainType().startsWith("io.swagger")) {
         continue;
       }
       final String annotationName = annotationMirror.getAnnotationType().toString();
-      final StringBuilder sb = new StringBuilder("  @").append(annotationName).append("(");
+      final StringBuilder sb = new StringBuilder(indent).append("@").append(annotationName).append("(");
       boolean first = true;
 
       for (final var entry : annotationMirror.getElementValues().entrySet()) {

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -72,15 +72,17 @@ class ClientMethodWriter {
     }
     method.checkArgumentNames();
 
-    segmentPropertyMap.forEach((k, v) -> {
-      writer.append("  private static final String %s = ", v);
-      final String getProperty = useConfig ? "Config.get(" : "System.getProperty(";
-      writer.append(getProperty).append("\"%s\");", k).eol();
-    });
-
     writer.append("  // %s %s", webMethod, method.webMethodPath()).eol();
+
+    segmentPropertyMap.forEach(
+        (k, v) -> {
+          writer.append("  private static final String %s = ", v);
+          final String getProperty = useConfig ? "Config.get(" : "System.getProperty(";
+          writer.append(getProperty).append("\"%s\");", k).eol();
+        });
+
     writer.append("  @Override").eol();
-    AnnotationUtil.writeAnnotations(writer, method.element());
+    AnnotationUtil.writeAnnotations(writer, method.element(),"  ");
     writer.append("  public %s%s %s(", methodGenericParams, returnType.shortType(), method.simpleName());
     int count = 0;
     List<MethodParam> params = method.params();


### PR DESCRIPTION
- Now will only write the extra spaces for anotations when generating methods
- move property constants below the URI comments