### PR TITLE
[http-client] Prevent Duplicate Constants

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -9,6 +9,7 @@ import javax.lang.model.util.ElementFilter;
 
 import static java.util.stream.Collectors.toMap;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,6 +36,7 @@ class ClientMethodWriter {
   private final Optional<RequestTimeoutPrism> timeout;
   private final boolean useConfig;
   private final Map<String, String> segmentPropertyMap;
+  private final Set<String> propertyConstants = new HashSet<>();
 
   ClientMethodWriter(MethodReader method, Append writer, boolean useJsonb) {
     this.method = method;
@@ -76,6 +78,11 @@ class ClientMethodWriter {
 
     segmentPropertyMap.forEach(
         (k, v) -> {
+
+          if (!propertyConstants.add(v)) {
+            return;
+          }
+
           writer.append("  private static final String %s = ", v);
           final String getProperty = useConfig ? "Config.get(" : "System.getProperty(";
           writer.append(getProperty).append("\"%s\");", k).eol();

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -36,9 +36,10 @@ class ClientMethodWriter {
   private final Optional<RequestTimeoutPrism> timeout;
   private final boolean useConfig;
   private final Map<String, String> segmentPropertyMap;
-  private final Set<String> propertyConstants = new HashSet<>();
+  private final Set<String> propertyConstants;
 
-  ClientMethodWriter(MethodReader method, Append writer, boolean useJsonb) {
+  ClientMethodWriter(
+      MethodReader method, Append writer, boolean useJsonb, Set<String> propertyConstants) {
     this.method = method;
     this.writer = writer;
     this.webMethod = method.webMethod();
@@ -47,9 +48,11 @@ class ClientMethodWriter {
     this.timeout = method.timeout();
     this.useConfig = ProcessingContext.typeElement("io.avaje.config.Config") != null;
 
-    this.segmentPropertyMap = method.pathSegments().segments().stream()
-      .filter(Segment::isProperty)
-      .collect(toMap(Segment::name, s -> Util.sanitizeName(s.name()).toUpperCase()));
+    this.segmentPropertyMap =
+        method.pathSegments().segments().stream()
+            .filter(Segment::isProperty)
+            .collect(toMap(Segment::name, s -> Util.sanitizeName(s.name()).toUpperCase()));
+    this.propertyConstants = propertyConstants;
   }
 
   void addImportTypes(ControllerReader reader) {

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
@@ -3,11 +3,12 @@ package io.avaje.http.generator.client;
 import io.avaje.http.generator.core.BaseControllerWriter;
 import io.avaje.http.generator.core.ControllerReader;
 import io.avaje.http.generator.core.MethodReader;
-import io.avaje.http.generator.core.ProcessingContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Write Http client adapter.
@@ -21,6 +22,8 @@ class ClientWriter extends BaseControllerWriter {
 
   private final List<ClientMethodWriter> methodList = new ArrayList<>();
   private final boolean useJsonb;
+  private final Set<String> propertyConstants = new HashSet<>();
+
 
   ClientWriter(ControllerReader reader, boolean useJsonB) throws IOException {
     super(reader, SUFFIX);
@@ -39,7 +42,7 @@ class ClientWriter extends BaseControllerWriter {
   private void readMethods() {
     for (final MethodReader method : reader.methods()) {
       if (method.isWebMethod()) {
-        final var methodWriter = new ClientMethodWriter(method, writer, useJsonb);
+        final var methodWriter = new ClientMethodWriter(method, writer, useJsonb, propertyConstants);
         methodWriter.addImportTypes(reader);
         methodList.add(methodWriter);
       }

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/TitanFall.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/TitanFall.java
@@ -7,5 +7,9 @@ import io.avaje.http.api.Get;
 public interface TitanFall {
 
   @Get("/${titan}/${drop.point}")
-  Titan titanfall();
+  Titan titanFall();
+
+
+  @Get("/${titan}/copium")
+  Titan titanFall3();
 }


### PR DESCRIPTION
now stuff like this works:
```java
public interface TitanFall {

  @Get("/${titan}/${drop.point}")
  Titan titanFall();


  @Get("/${titan}/copium")
  Titan titanFall3();
}
```