### PR TITLE
[http-generator-core] OpenAPI Schema nullable property - Added support for NotEmpty and NotBlank 

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Stream;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -296,7 +297,10 @@ class SchemaDocBuilder {
 
   private boolean isNotNullable(Element element) {
     return element.getAnnotationMirrors().stream()
-        .anyMatch(m -> m.toString().contains("@") && m.toString().contains("NotNull"));
+      .anyMatch(m -> m.toString().contains("@") &&
+        Stream.of("NotNull", "NotEmpty", "NotBlank")
+          .anyMatch(annotation -> m.toString().contains(annotation))
+      );
   }
 
   /**


### PR DESCRIPTION
Currently, only `NotNull` is supported