### PR TITLE
[http-generator-core] added required props

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/SchemaDocBuilder.java
@@ -249,6 +249,7 @@ class SchemaDocBuilder {
       Schema<?> propSchema = toSchema(field.asType());
       if (isNotNullable(field)) {
         propSchema.setNullable(Boolean.FALSE);
+        objectSchema.addRequiredItem(field.getSimpleName().toString());
       }
       setDescription(field, propSchema);
       setLengthMinMax(field, propSchema);


### PR DESCRIPTION
This is to add support for `required` label on fields that are not nullable (any of "NotNull", "NotEmpty", "NotBlank") 

```json
  "components": {
    "schemas": {
      "Provider": {
        "required": [
          "firstName",
          "lastName"
        ],
        "type": "object",
        "properties": {
          "firstName": {
            "type": "string",
            "nullable": false
          },
          "middleName": {
            "type": "string"
          },
          "lastName": {
            "type": "string",
            "nullable": false
          }
        }
      }
    }
  }
```

Sample redoc

<img width="871" alt="image" src="https://github.com/avaje/avaje-http/assets/8675872/45917744-3a39-49e5-a7a4-91e75cef19bc">
