### PR TITLE
Fix Javalin 5 generation not triggering properly

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -86,7 +86,7 @@ public class ProcessingContext {
       } else {
         useJavax = (javax);
       }
-      this.javalin6 = elementUtils.getTypeElement("io.javalin.config.JavalinConfig") != null;
+      this.javalin6 = elementUtils.getTypeElement("io.javalin.config.RouterConfig") != null;
     }
   }
 


### PR DESCRIPTION
`io.javalin.config.JavalinConfig` is in both 5 and 6, which causes controllers to only generate with Javalin 6.

- now uses `io.javalin.config.RouterConfig` to determine if on Javalin 6