### PR TITLE
[http client] Add `jdk.crypto.ec` to http client module

### DIFF
--- a/http-client/src/main/java/module-info.java
+++ b/http-client/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module io.avaje.http.client {
   uses io.avaje.http.client.HttpClient.GeneratedComponent;
 
   requires transitive java.net.http;
+  requires transitive jdk.crypto.ec;
   requires transitive io.avaje.applog;
   requires static com.fasterxml.jackson.databind;
   requires static com.fasterxml.jackson.annotation;


### PR DESCRIPTION
To call things via ssl this is required, and yet I often forget to add it when creating jlink images