### PR TITLE
Remove `jdk.crypto.ec`

### DIFF
--- a/http-client/src/main/java/module-info.java
+++ b/http-client/src/main/java/module-info.java
@@ -3,7 +3,6 @@ module io.avaje.http.client {
   uses io.avaje.http.client.HttpClient.GeneratedComponent;
 
   requires transitive java.net.http;
-  requires transitive jdk.crypto.ec;
   requires transitive io.avaje.applog;
   requires static com.fasterxml.jackson.databind;
   requires static com.fasterxml.jackson.annotation;


### PR DESCRIPTION
It's deprecated now I guess: https://bugs.openjdk.org/browse/JDK-8312267