### PR TITLE
[http-client] Add `@Headers` Annotation

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/Headers.java
+++ b/http-api/src/main/java/io/avaje/http/api/Headers.java
@@ -1,0 +1,32 @@
+package io.avaje.http.api;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Headers for an Http <code>@Client</code> interface method.
+ *
+ * <p>We can put this on a method or the interface to add preset headers to the generated
+ * implementation bean property.
+ *
+ * <pre>{@code
+ * @Headers({
+ * "Accept: application/vnd.github.v3.full+json",
+ * "User-Agent: Avaje-Sample-App"
+ * })
+ * @Get("users/{username}")
+ * User getUser(@Path("username") String username);
+ *
+ * }</pre>
+ */
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+public @interface Headers {
+
+  /** The array of headers */
+  String[] value();
+}

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -58,21 +58,21 @@ final class ClientMethodWriter {
     var element = method.element();
 
     this.presetHeaders =
-        Stream.concat(
-                HeadersPrism.getOptionalOn(element).stream(),
-                HeadersPrism.getOptionalOn(element.getEnclosingElement()).stream())
-            .map(HeadersPrism::value)
-            .map(List::stream)
-            .flatMap(Function.identity())
-            .peek(
-                s -> {
-                  if (!s.contains(":")) {
-                    logError(element, "@Headers value must have a \":\"", method);
-                  }
-                })
-            .map(s -> s.split(":", 2))
-            .filter(a -> a.length == 2)
-            .map(a -> Map.entry(a[0].trim(), a[1].trim())).collect(toList());
+      Stream.concat(
+        HeadersPrism.getOptionalOn(element).stream(),
+        HeadersPrism.getOptionalOn(element.getEnclosingElement()).stream())
+      .map(HeadersPrism::value)
+      .map(List::stream)
+      .flatMap(Function.identity())
+      .peek(
+        s -> {
+          if (!s.contains(":")) {
+            logError(element, "@Headers value must have a \":\"", method);
+          }
+        })
+      .map(s -> s.split(":", 2))
+      .filter(a -> a.length == 2)
+      .map(a -> Map.entry(a[0].trim(), a[1].trim())).collect(toList());
   }
 
   void addImportTypes(ControllerReader reader) {
@@ -295,12 +295,8 @@ final class ClientMethodWriter {
         }
       }
     }
-    presetHeaders.forEach(
-        e ->
-            writer
-                .append(
-                    "      .header(\"%s\", \"%s\")", e.getKey(), e.getValue().replace("\\", "\\\\"))
-                .eol());
+    presetHeaders.forEach(e ->
+      writer.append("      .header(\"%s\", \"%s\")", e.getKey(), e.getValue().replace("\\", "\\\\")).eol());
   }
 
   private void writeBeanParams(PathSegments segments) {

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -7,11 +7,15 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.avaje.http.generator.core.ProcessingContext.*;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -35,6 +39,7 @@ final class ClientMethodWriter {
   private final boolean useConfig;
   private final Map<String, String> segmentPropertyMap;
   private final Set<String> propertyConstants;
+  private final List<Entry<String, String>> presetHeaders;
 
   ClientMethodWriter(MethodReader method, Append writer, boolean useJsonb, Set<String> propertyConstants) {
     this.method = method;
@@ -50,6 +55,24 @@ final class ClientMethodWriter {
         .filter(Segment::isProperty)
         .collect(toMap(Segment::name, s -> Util.sanitizeName(s.name()).toUpperCase()));
     this.propertyConstants = propertyConstants;
+    var element = method.element();
+
+    this.presetHeaders =
+        Stream.concat(
+                HeadersPrism.getOptionalOn(element).stream(),
+                HeadersPrism.getOptionalOn(element.getEnclosingElement()).stream())
+            .map(HeadersPrism::value)
+            .map(List::stream)
+            .flatMap(Function.identity())
+            .peek(
+                s -> {
+                  if (!s.contains(":")) {
+                    logError(element, "@Headers value must have a \":\"", method);
+                  }
+                })
+            .map(s -> s.split(":", 2))
+            .filter(a -> a.length == 2)
+            .map(a -> Map.entry(a[0].trim(), a[1].trim())).collect(toList());
   }
 
   void addImportTypes(ControllerReader reader) {
@@ -272,6 +295,12 @@ final class ClientMethodWriter {
         }
       }
     }
+    presetHeaders.forEach(
+        e ->
+            writer
+                .append(
+                    "      .header(\"%s\", \"%s\")", e.getKey(), e.getValue().replace("\\", "\\\\"))
+                .eol());
   }
 
   private void writeBeanParams(PathSegments segments) {

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -21,7 +21,9 @@ import io.avaje.http.generator.core.ClientPrism;
 import io.avaje.http.generator.core.ControllerReader;
 import io.avaje.http.generator.core.ImportPrism;
 import io.avaje.http.generator.core.ProcessingContext;
+import io.avaje.prism.GeneratePrism;
 
+@GeneratePrism(io.avaje.http.api.Headers.class)
 @SupportedAnnotationTypes({ClientPrism.PRISM_TYPE, ImportPrism.PRISM_TYPE})
 public class ClientProcessor extends AbstractProcessor {
 

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/TitanFall.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/TitanFall.java
@@ -2,14 +2,18 @@ package io.avaje.http.generator.client.clients;
 
 import io.avaje.http.api.Client;
 import io.avaje.http.api.Get;
+import io.avaje.http.api.Headers;
 
 @Client
+@Headers("Content-Type: applicaton/json")
 public interface TitanFall {
 
   @Get("/${titan}/${drop.point}")
+  @Headers("Something: \\invalid\n\t")
   Titan titanFall();
 
 
   @Get("/${titan}/copium")
+  @Headers("      Accept    :   applicaton/json")
   Titan titanFall3();
 }


### PR DESCRIPTION
Adds something like Retrofits `@Headers` (I got sick of making default methods to add preset headers)

Now we can do stuff like this:

```java
@Client
@Headers("Content-Type: applicaton/json")
public interface TitanFall {

  @Get("/${titan}/${drop.point}")
  @Headers("Something: \\invalid\n\t")
  Titan titanFall();


  @Get("/${titan}/copium")
  @Headers("      Accept    :   applicaton/json")
  Titan titanFall3();
}
```

and the generated class will have

```java
  // GET /${titan}/${drop.point}
  private static final String DROP_POINT = System.getProperty("drop.point");
  private static final String TITAN = System.getProperty("titan");
  @Override
  public Titan titanFall() {
    return client.request()
      .header("Something", "\\invalid")
      .header("Content-Type", "applicaton/json")
      .path(TITAN).path(DROP_POINT)
      .GET()
      .bean(Titan.class);
  }

  // GET /${titan}/copium
  @Override
  public Titan titanFall3() {
    return client.request()
      .header("Accept", "applicaton/json")
      .header("Content-Type", "applicaton/json")
      .path(TITAN).path("copium")
      .GET()
      .bean(Titan.class);
  }