### PR TITLE
Can now read record Javadocs for OpenApi

### DIFF
--- a/tests/test-nima-jsonb/src/main/java/org/example/Person.java
+++ b/tests/test-nima-jsonb/src/main/java/org/example/Person.java
@@ -2,7 +2,9 @@ package org.example;
 
 import io.avaje.jsonb.Json;
 
+/**
+ * @param id the id
+ * @param name the name
+ */
 @Json
-public record Person(long id, String name) {
-
-}
+public record Person(long id, String name) {}


### PR DESCRIPTION
Modifies the schema builder to retrieve the record javadocs and associate the `@param`s with a record component 