### PR TITLE
Dependabot Grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,21 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   open-pull-requests-limit: 10
+  groups:
+      dev-deps:
+        dependency-type: "development"
+      prod-deps:
+        dependency-type: "production"
+
+- package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "[workflow]"
+    labels:
+      - "dependencies"
+    target-branch: "master"


### PR DESCRIPTION
Can now update multiple dependencies at once, reducing the amount of PRs