### PR TITLE
[HttpClient] Generated client to use suffix of Impl or HttpClient

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -101,7 +101,8 @@ public class ClientProcessor extends AbstractProcessor {
   }
 
   protected String writeClientAdapter(ControllerReader reader) throws IOException {
-    return new ClientWriter(reader, useJsonB).write();
+    var suffix = ClientSuffix.fromInterface(reader.beanType().getQualifiedName().toString());
+    return new ClientWriter(reader, suffix, useJsonB).write();
   }
 
   private void initialiseComponent() {

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientSuffix.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientSuffix.java
@@ -1,0 +1,56 @@
+package io.avaje.http.generator.client;
+
+/**
+ * Handling client naming suffix.
+ * <p>
+ * The suffix chosen should avoid repeating "HttpClient" or "Client"
+ * in the generated class name.
+ */
+final class ClientSuffix {
+
+  private static final String SUB_PACKAGE = ".httpclient";
+
+  /**
+   * Return the suffix to use for the generated client given the
+   * client interface name.
+   */
+  static String fromInterface(String fullName) {
+    if (fullName.endsWith("Client")) {
+      return "Impl";
+    } else {
+      return "HttpClient";
+    }
+  }
+
+  /**
+   * Remove the suffix from the generated name.
+   */
+  static String removeSuffix(String clientName) {
+    if (clientName.endsWith("Impl")) {
+      return trim(clientName, 4);
+    } else if (clientName.endsWith("HttpClient")) {
+      return trim(clientName, 10);
+    } else {
+      return clientName;
+    }
+  }
+
+  /**
+   * Return the interface name from the generated client name.
+   */
+  static String toInterface(String clientName) {
+    return removeSubPackage(removeSuffix(clientName));
+  }
+
+  private static String trim(String name, int length) {
+    return name.substring(0, name.length() - length);
+  }
+
+  private static String removeSubPackage(String className) {
+    final int pos = className.lastIndexOf(SUB_PACKAGE);
+    if (pos > -1) {
+      return className.substring(0, pos) + className.substring(pos + SUB_PACKAGE.length());
+    }
+    return className;
+  }
+}

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
@@ -18,15 +18,15 @@ class ClientWriter extends BaseControllerWriter {
   private static final String HTTP_CLIENT = "io.avaje.http.client.HttpClient";
 
   private static final String AT_GENERATED = "@Generated(\"avaje-http-client-generator\")";
-  private static final String SUFFIX = "HttpClient";
 
   private final List<ClientMethodWriter> methodList = new ArrayList<>();
   private final boolean useJsonb;
   private final Set<String> propertyConstants = new HashSet<>();
+  private final String suffix;
 
-
-  ClientWriter(ControllerReader reader, boolean useJsonB) throws IOException {
-    super(reader, SUFFIX);
+  ClientWriter(ControllerReader reader, String suffix, boolean useJsonB) throws IOException {
+    super(reader, suffix);
+    this.suffix = suffix;
     reader.addImportType(HTTP_CLIENT);
     this.useJsonb = useJsonB;
     readMethods();
@@ -67,11 +67,11 @@ class ClientWriter extends BaseControllerWriter {
   private void writeClassStart() {
     writer.append(AT_GENERATED).eol();
     AnnotationUtil.writeAnnotations(writer, reader.beanType());
-    writer.append("public class %s%s implements %s {", shortName, SUFFIX, shortName).eol().eol();
+    writer.append("public class %s%s implements %s {", shortName, suffix, shortName).eol().eol();
 
     writer.append("  private final HttpClient client;").eol().eol();
 
-    writer.append("  public %s%s(HttpClient client) {", shortName, SUFFIX).eol();
+    writer.append("  public %s%s(HttpClient client) {", shortName, suffix).eol();
     writer.append("    this.client = client;").eol();
     writer.append("  }").eol().eol();
   }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentMetaData.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentMetaData.java
@@ -52,17 +52,9 @@ final class ComponentMetaData {
   Collection<String> allImports() {
     final Set<String> packageImports = new TreeSet<>(generatedClients);
     generatedClients.stream()
-        .map(s -> removeLast(removeLast(s, ".httpclient"), "HttpClient"))
-        .forEach(packageImports::add);
+      .map(ClientSuffix::toInterface)
+      .forEach(packageImports::add);
 
     return packageImports;
-  }
-
-  public static String removeLast(String className, String search) {
-    final int pos = className.lastIndexOf(search);
-    if (pos > -1) {
-      return className.substring(0, pos) + className.substring(pos + search.length());
-    }
-    return className;
   }
 }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/SimpleComponentWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/SimpleComponentWriter.java
@@ -64,7 +64,7 @@ final class SimpleComponentWriter {
 
     for (final String clientFullName : metaData.all()) {
       final String clientShortName = Util.shortName(clientFullName);
-      final var clientInterface = ComponentMetaData.removeLast(clientShortName, "HttpClient");
+      final String clientInterface = ClientSuffix.removeSuffix(clientShortName);
       writer.append("    providerMap.put(%s.class, %s::new);", clientInterface, clientShortName).eol();
     }
     writer.append("  }").eol().eol();
@@ -102,7 +102,6 @@ final class SimpleComponentWriter {
     importTypes.addAll(metaData.allImports());
 
     for (final String importType : importTypes) {
-      writer.append("import %s;", importType).eol();
       writer.append("import %s;", importType).eol();
     }
     writer.eol();

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/ClientSuffixTest.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/ClientSuffixTest.java
@@ -1,0 +1,30 @@
+package io.avaje.http.generator.client;
+
+import org.junit.jupiter.api.Test;
+
+import static io.avaje.http.generator.client.ClientSuffix.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClientSuffixTest {
+
+  @Test
+  void testFromInterface() {
+    assertEquals("Impl", fromInterface("foo.MyClient"));
+    assertEquals("Impl", fromInterface("foo.MyHttpClient"));
+    assertEquals("HttpClient", fromInterface("foo.My"));
+  }
+
+  @Test
+  void testRemoveSuffix() {
+    assertEquals("foo.MyClient", removeSuffix("foo.MyClientImpl"));
+    assertEquals("foo.MyHttpClient", removeSuffix("foo.MyHttpClientImpl"));
+    assertEquals("foo.My", removeSuffix("foo.MyHttpClient"));
+  }
+
+  @Test
+  void testToInterface() {
+    assertEquals("foo.MyClient", toInterface("foo.httpclient.MyClientImpl"));
+    assertEquals("foo.MyHttpClient", toInterface("foo.httpclient.MyHttpClientImpl"));
+    assertEquals("foo.My", toInterface("foo.httpclient.MyHttpClient"));
+  }
+}

--- a/tests/test-client-generation/src/main/java/org/example/MyOtherHttpClient.java
+++ b/tests/test-client-generation/src/main/java/org/example/MyOtherHttpClient.java
@@ -1,0 +1,11 @@
+package org.example;
+
+import io.avaje.http.api.*;
+
+@Client
+public interface MyOtherHttpClient {
+
+  @Post
+  String asPlainString();
+
+}

--- a/tests/test-client-generation/src/main/java/org/example/MySillyClient.java
+++ b/tests/test-client-generation/src/main/java/org/example/MySillyClient.java
@@ -1,0 +1,11 @@
+package org.example;
+
+import io.avaje.http.api.*;
+
+@Client
+public interface MySillyClient {
+
+  @Post
+  String asPlainString();
+
+}


### PR DESCRIPTION
Avoid duplicating HttpClient or Client in the generated client class name. If the client interface ends in "Client" then use the suffix of "Impl" otherwise use "HttpClient".