### PR TITLE
[Http-Client] Use virtual thread executor by default

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientBuilder.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientBuilder.java
@@ -105,7 +105,7 @@ final class DHttpClientBuilder implements HttpClient.Builder, HttpClient.Builder
     }
     if (executor != null) {
       builder.executor(executor);
-    } else {
+    } else if (Integer.getInteger("java.specification.version") >= 21) {
       try {
         ExecutorService virtualExecutorService =
             (ExecutorService)
@@ -117,7 +117,7 @@ final class DHttpClientBuilder implements HttpClient.Builder, HttpClient.Builder
                     .invokeExact();
         builder.executor(virtualExecutorService);
       } catch (Throwable t) {
-        // Nothing to do
+        // Impossible
       }
     }
     if (proxy != null) {

--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientBuilder.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientBuilder.java
@@ -16,9 +16,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 
 final class DHttpClientBuilder implements HttpClient.Builder, HttpClient.Builder.State {
 
@@ -99,6 +105,20 @@ final class DHttpClientBuilder implements HttpClient.Builder, HttpClient.Builder
     }
     if (executor != null) {
       builder.executor(executor);
+    } else {
+      try {
+        ExecutorService virtualExecutorService =
+            (ExecutorService)
+                MethodHandles.lookup()
+                    .findStatic(
+                        Executors.class,
+                        "newVirtualThreadPerTaskExecutor",
+                        MethodType.methodType(ExecutorService.class))
+                    .invokeExact();
+        builder.executor(virtualExecutorService);
+      } catch (Throwable t) {
+        // Nothing to do
+      }
     }
     if (proxy != null) {
       builder.proxy(proxy);


### PR DESCRIPTION
When on JDK 21+, the builder will default to the `VirtualThreadPerTask` Executor for the underlying `HttpClient`.