### PR TITLE
Use avaje spi for service validation when available

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -17,6 +17,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
+import io.avaje.http.generator.core.APContext;
 import io.avaje.http.generator.core.ClientPrism;
 import io.avaje.http.generator.core.ControllerReader;
 import io.avaje.http.generator.core.ImportPrism;
@@ -44,6 +45,7 @@ public class ClientProcessor extends AbstractProcessor {
   public synchronized void init(ProcessingEnvironment processingEnv) {
     super.init(processingEnv);
     this.processingEnv = processingEnv;
+    APContext.init(processingEnv);
     ProcessingContext.init(processingEnv, new ClientPlatformAdapter(), false);
     this.componentWriter = new SimpleComponentWriter(metaData);
     useJsonB = ProcessingContext.useJsonb();
@@ -51,7 +53,7 @@ public class ClientProcessor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
-    ProcessingContext.findModule(annotations, round);
+    APContext.setProjectModuleElement(annotations, round);
     final var platform = platform();
     if (!(platform instanceof ClientPlatformAdapter)) {
       setPlatform(new ClientPlatformAdapter());
@@ -107,7 +109,8 @@ public class ClientProcessor extends AbstractProcessor {
   private void initialiseComponent() {
     metaData.initialiseFullName();
     if (!metaData.all().isEmpty()) {
-      ProcessingContext.validateModule(metaData.fullName());
+      ProcessingContext.addClientComponent(metaData.fullName());
+      ProcessingContext.validateModule();
     }
     try {
       componentWriter.init();

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
@@ -22,6 +22,11 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
 
+import io.avaje.prism.GenerateAPContext;
+import io.avaje.prism.GenerateModuleInfoReader;
+
+@GenerateAPContext
+@GenerateModuleInfoReader
 @SupportedOptions({"useJavax", "useSingleton", "instrumentRequests","disableDirectWrites"})
 public abstract class BaseProcessor extends AbstractProcessor {
 
@@ -42,6 +47,7 @@ public abstract class BaseProcessor extends AbstractProcessor {
   @Override
   public synchronized void init(ProcessingEnvironment processingEnv) {
     super.init(processingEnv);
+    APContext.init(processingEnv);
     ProcessingContext.init(processingEnv, providePlatformAdapter());
   }
 
@@ -51,7 +57,7 @@ public abstract class BaseProcessor extends AbstractProcessor {
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
     var pathElements = round.getElementsAnnotatedWith(typeElement(PathPrism.PRISM_TYPE));
-
+    APContext.setProjectModuleElement(annotations, round);
     if (contextPathString == null) {
       contextPathString =
           ElementFilter.modulesIn(pathElements).stream()
@@ -79,6 +85,7 @@ public abstract class BaseProcessor extends AbstractProcessor {
 
     if (round.processingOver()) {
       writeOpenAPI();
+      ProcessingContext.validateModule();
     }
     return false;
   }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -1,22 +1,17 @@
 package io.avaje.http.generator.core;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.ModuleElement;
@@ -31,6 +26,7 @@ import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 
+import io.avaje.http.generator.core.ModuleInfoReader.Provides;
 import io.avaje.http.generator.core.openapi.DocContext;
 
 public final class ProcessingContext {
@@ -53,8 +49,9 @@ public final class ProcessingContext {
     private final boolean instrumentAllMethods;
     private final boolean disableDirectWrites;
     private final boolean javalin6;
-    private ModuleElement module;
+    private final boolean spiPresent = APContext.typeElement("io.avaje.spi.internal.ServiceProcessor") != null;
     private boolean validated;
+    private String clientFQN;
 
     Ctx(ProcessingEnvironment env, PlatformAdapter adapter, boolean generateOpenAPI) {
       readAdapter = adapter;
@@ -146,7 +143,12 @@ public final class ProcessingContext {
 
   /** Create a file writer for the META-INF services file. */
   public static FileObject createMetaInfWriter(String target) throws IOException {
-    return CTX.get().filer.createResource(StandardLocation.CLASS_OUTPUT, "", target);
+    var serviceFile =
+        CTX.get().spiPresent
+            ? target.replace("META-INF/services/", "META-INF/generated-services/")
+            : target;
+
+    return filer().createResource(StandardLocation.CLASS_OUTPUT, "", serviceFile);
   }
 
   public static JavaFileObject createWriter(String cls) throws IOException {
@@ -237,39 +239,39 @@ public final class ProcessingContext {
         .map(Object::toString);
   }
 
-  public static void findModule(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    if (CTX.get().module == null) {
-      CTX.get().module =
-          annotations.stream()
-              .map(roundEnv::getElementsAnnotatedWith)
-              .flatMap(Collection::stream)
-              .findAny()
-              .map(ProcessingContext::getModuleElement)
-              .orElse(null);
-    }
-  }
-
-  public static void validateModule(String fqn) {
-    var module = CTX.get().module;
+  public static void validateModule() {
+    var module = APContext.getProjectModuleElement();
     if (module != null && !CTX.get().validated && !module.isUnnamed()) {
 
       CTX.get().validated = true;
-      try (var inputStream =
-             CTX.get()
-               .filer
-               .getResource(StandardLocation.SOURCE_PATH, "", "module-info.java")
-               .toUri()
-               .toURL()
-               .openStream();
-          var reader = new BufferedReader(new InputStreamReader(inputStream))) {
+      try (var bufferedReader = APContext.getModuleInfoReader()) {
+        var reader = new ModuleInfoReader(module, bufferedReader);
+        reader
+            .requires()
+            .forEach(
+                r -> {
+                  if (!r.isStatic()
+                      && r.getDependency()
+                          .getQualifiedName()
+                          .contentEquals("io.avaje.http.api.javalin")) {
+                    logWarn(
+                        module,
+                        "io.avaje.http.api.javalin only contains SOURCE retention annotations. It should added as `requires static`");
+                  }
+                });
+        var fqn = CTX.get().clientFQN;
+        if (CTX.get().spiPresent || fqn == null) {
+          return;
+        }
 
-        var noProvides = reader.lines().map(s -> {
-            if (s.contains("io.avaje.http.api.javalin") && !s.contains("static")) {
-              logWarn("io.avaje.http.api.javalin only contains SOURCE retention annotations. It should added as `requires static`");
-            }
-            return s;
-          })
-          .noneMatch(s -> s.contains(fqn));
+        var noProvides =
+            reader.provides().stream()
+                .filter(
+                    p -> "io.avaje.http.client.HttpClient.GeneratedComponent".equals(p.service()))
+                .map(Provides::implementations)
+                .flatMap(List::stream)
+                .noneMatch(s -> s.contains(fqn));
+
         if (noProvides && !buildPluginAvailable()) {
           logError(module, "Missing `provides io.avaje.http.client.HttpClient.GeneratedComponent with %s;`", fqn);
         }
@@ -308,5 +310,9 @@ public final class ProcessingContext {
     } catch (final Exception e) {
       return false;
     }
+  }
+
+  public static void addClientComponent(String clientFQN) {
+    CTX.get().clientFQN = clientFQN;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
     <swagger.version>2.2.22</swagger.version>
     <jackson.version>2.14.2</jackson.version>
-    <avaje.prisms.version>1.24</avaje.prisms.version>
+    <avaje.prisms.version>1.25</avaje.prisms.version>
     <module-info.shade>${project.build.directory}${file.separator}module-info.shade</module-info.shade>
   </properties>
 


### PR DESCRIPTION
- will write services to `META-INF/generated services` if avaje spi is detected (I haven't added it as a transitive dependency because of potential shading shenanigans)
- uses avaje prisms to read and validate module-infos
- will run module validations on all processors