### PR TITLE
Update Dependabot Grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,15 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      dependencies:
+        patterns:
+        - "*"
     labels:
       - "dependencies"
     target-branch: "master"
-
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Now dependabot should create a single PR for all the dependencies. [Example PR](https://github.com/SentryMan/avaje-javalin-api-example/pull/50)