### PR TITLE
Add roles support for Helidon

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ public class WidgetController$Route implements HttpFeature {
   private void _getById(ServerRequest req, ServerResponse res) throws Exception {
     res.status(OK_200);
     var pathParams = req.path().pathParameters();
-    var id = asInt(pathParams.first("id").get());
+    var id = asInt(pathParams.contains("id") ? pathParams.get("id") : null);
     var result = controller.getById(id);
     res.send(result);
   }
@@ -263,7 +263,7 @@ public class WidgetController$Route implements HttpFeature {
   private void _getById(ServerRequest req, ServerResponse res) throws Exception {
     res.status(OK_200);
     var pathParams = req.path().pathParameters();
-    var id = asInt(pathParams.first("id").get());
+    var id = asInt(pathParams.contains("id") ? pathParams.get("id") : null);
     var result = controller.getById(id);
     res.headers().contentType(MediaTypes.APPLICATION_JSON);
     //jsonb has a special accommodation for helidon to improve performance

--- a/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/ControllerMethodWriter.java
+++ b/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/ControllerMethodWriter.java
@@ -88,6 +88,15 @@ final class ControllerMethodWriter {
       writer.append("    routing.addFilter(this::_%s);", method.simpleName()).eol();
     } else {
       writer.append("    routing.%s(\"%s\", ", webMethod.name().toLowerCase(), method.fullPath().replace("\\", "\\\\"));
+      var roles = method.roles();
+      if (!roles.isEmpty()) {
+        writer.append("SecurityFeature.rolesAllowed(");
+        writer.append("\"%s\"", Util.shortName(roles.getFirst(), true));
+        for (var i = 1; i < roles.size(); i++) {
+          writer.append(", \"%s\"", Util.shortName(roles.get(i), true));
+        }
+        writer.append("), ");
+      }
       var hxRequest = method.hxRequest();
       if (hxRequest != null) {
         writer.append("HxHandler.builder(this::_%s)", method.simpleName());

--- a/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
+++ b/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
@@ -50,6 +50,9 @@ class ControllerWriter extends BaseControllerWriter {
     reader.addImportType("io.helidon.webserver.http.ServerResponse");
     reader.addImportType("io.helidon.webserver.http.HttpFeature");
     reader.addImportType("io.helidon.http.HeaderNames");
+    if (!reader.roles().isEmpty() || reader.methods().stream().anyMatch(m -> !m.roles().isEmpty())) {
+      reader.addImportType("io.helidon.webserver.security.SecurityFeature");
+    }
     if (reader.isIncludeValidator()) {
       reader.addImportType("io.helidon.http.HeaderName");
     }

--- a/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/NimaPlatformAdapter.java
+++ b/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/NimaPlatformAdapter.java
@@ -61,7 +61,9 @@ class NimaPlatformAdapter implements PlatformAdapter {
   }
 
   private void addRoleImports(List<String> roles, ControllerReader controller) {
-    // nothing here yet
+    for (final String role : roles) {
+      controller.addStaticImportType(role);
+    }
   }
 
   @Override

--- a/tests/test-nima/pom.xml
+++ b/tests/test-nima/pom.xml
@@ -34,6 +34,11 @@
       <version>${nima.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.helidon.webserver</groupId>
+      <artifactId>helidon-webserver-security</artifactId>
+      <version>${nima.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.helidon.http.media</groupId>
       <artifactId>helidon-http-media-jsonb</artifactId>
       <version>${nima.version}</version>

--- a/tests/test-nima/src/main/java/org/example/AppRoles.java
+++ b/tests/test-nima/src/main/java/org/example/AppRoles.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public enum AppRoles {
+  ANYONE, ADMIN, BASIC_USER
+}

--- a/tests/test-nima/src/main/java/org/example/HelloController.java
+++ b/tests/test-nima/src/main/java/org/example/HelloController.java
@@ -2,6 +2,7 @@ package org.example;
 
 import io.avaje.http.api.Controller;
 import io.avaje.http.api.Get;
+import io.avaje.http.api.Produces;
 
 @Controller
 public class HelloController {
@@ -17,5 +18,12 @@ public class HelloController {
     p.setId(42);
     p.setName(name + " hello" + " sortBy:" + sortBy);
     return p;
+  }
+
+  @Roles({AppRoles.ADMIN, AppRoles.BASIC_USER})
+  @Produces("text/plain")
+  @Get("other/{name}")
+  String name(String name) {
+    return "hi " + name;
   }
 }

--- a/tests/test-nima/src/main/java/org/example/Roles.java
+++ b/tests/test-nima/src/main/java/org/example/Roles.java
@@ -1,0 +1,21 @@
+package org.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specify permitted roles.
+ */
+@Target(value={METHOD, TYPE})
+@Retention(value=RUNTIME)
+public @interface Roles {
+
+  /**
+   * Specify the permitted roles.
+   */
+  AppRoles[] value() default {};
+}


### PR DESCRIPTION
Helidon has security providers e.g. OIDC. These integrate with WebServer Security as `SecurityHandler`s with the shorthand `SecurityFeature.rolesAllowed(<roles>)` and the authorization provider will then validate the role before delegating to the actual handler.

This PR takes Avaje's `@Roles` and populates them and the rest is up to Helidon.