### PR TITLE
[http-client] Make clients `AutoCloseable`

### DIFF
--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>2.9-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/http-client/src/main/java/io/avaje/http/client/HttpClient.java
+++ b/http-client/src/main/java/io/avaje/http/client/HttpClient.java
@@ -3,7 +3,6 @@ package io.avaje.http.client;
 import java.net.Authenticator;
 import java.net.CookieHandler;
 import java.net.ProxySelector;
-import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -33,7 +32,7 @@ import io.avaje.inject.BeanScope;
  *
  * }</pre>
  */
-public interface HttpClient {
+public interface HttpClient extends AutoCloseable {
 
   /**
    * Return the builder to config and build the client context.
@@ -92,6 +91,19 @@ public interface HttpClient {
    * These metrics are collected for all requests sent via this context.
    */
   HttpClient.Metrics metrics(boolean reset);
+
+  /**
+   * Note: invoking this method has no effect on JDK versions less than 21.
+   *
+   * <p>Initiates an orderly shutdown in which http requests previously submitted are run to
+   * completion, but no new requests will be accepted. Running a request to completion may involve
+   * running several operations in the background, including waiting for responses to be delivered.
+   * This method waits until all operations have completed execution and the client has terminated.
+   *
+   * @see {@linkplain java.net.http.HttpClient#close}
+   */
+  @Override
+  void close();
 
   /**
    * Builds the HttpClient.

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientWriter.java
@@ -1,5 +1,6 @@
 package io.avaje.http.generator.client;
 
+import io.avaje.http.generator.core.APContext;
 import io.avaje.http.generator.core.BaseControllerWriter;
 import io.avaje.http.generator.core.ControllerReader;
 import io.avaje.http.generator.core.MethodReader;
@@ -62,12 +63,17 @@ final class ClientWriter extends BaseControllerWriter {
     for (final ClientMethodWriter methodWriter : methodList) {
       methodWriter.write();
     }
+    writer.append("  @Override").eol();
+    writer.append("  public void close() {").eol();
+    writer.append("    this.client.close();").eol();
+    writer.append("  }").eol();
   }
 
   private void writeClassStart() {
     writer.append(AT_GENERATED).eol();
     AnnotationUtil.writeAnnotations(writer, reader.beanType());
-    writer.append("public class %s%s implements %s {", shortName, suffix, shortName).eol().eol();
+
+    writer.append("public class %s%s implements %s, AutoCloseable {", shortName, suffix, shortName).eol().eol();
 
     writer.append("  private final HttpClient client;").eol().eol();
 


### PR DESCRIPTION
Since JDK 21, `java.net.HttpClient` now extends `AutoCloseable`, should we not follow suit?

- `io.avaje.http.client.HttpClient` now extends `AutoCloseable` (has no effect unless on 21 or higher)
- generated Client interface implementations will now additionally implement AutoClosable as well