### PR TITLE
[http-client] Add BasicAuthIntercept.header() helper method

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/BasicAuthIntercept.java
+++ b/http-client/src/main/java/io/avaje/http/client/BasicAuthIntercept.java
@@ -4,17 +4,38 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Base64;
 
-/** Adds Basic Authorization header to requests. */
+/**
+ * Adds Basic Authorization header to requests.
+ */
 public final class BasicAuthIntercept implements RequestIntercept {
 
   private final String headerValue;
 
-  /** Construct with the username and password. */
+  /**
+   * Construct with the username and password.
+   */
   public BasicAuthIntercept(String username, String password) {
-    this.headerValue = "Basic " + encode(username, password);
+    this.headerValue = header(username, password);
   }
 
-  /** Return Base64 encoding of {@literal username:password} */
+  /**
+   * Return the Basic header value with the encoding of {@literal username:password}
+   * <p>
+   * Provided as a helper method for code that wants the header value to then
+   * apply explicitly rather than using this as a request intercept.
+   *
+   * @return {@code "Basic " + encode(username, password)}
+   */
+  public static String header(String username, String password) {
+    return "Basic " + encode(username, password);
+  }
+
+  /**
+   * Return Base64 encoding of {@literal username:password}
+   * <p>
+   * Provided as a helper method for code that wants to encode the username
+   * password pair and use that explicitly rather than using this as a request intercept.
+   */
   public static String encode(String username, String password) {
     return Base64.getEncoder().encodeToString((username + ":" + password).getBytes(UTF_8));
   }

--- a/http-client/src/test/java/io/avaje/http/client/BasicAuthInterceptTest.java
+++ b/http-client/src/test/java/io/avaje/http/client/BasicAuthInterceptTest.java
@@ -15,6 +15,12 @@ class BasicAuthInterceptTest {
   }
 
   @Test
+  void header() {
+    final String encode = BasicAuthIntercept.header("Aladdin", "open sesame");
+    assertThat(encode).isEqualTo("Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+  }
+
+  @Test
   void beforeRequest() {
     // setup
     final BasicAuthIntercept intercept = new BasicAuthIntercept("Aladdin", "open sesame");


### PR DESCRIPTION
Provided as a helper method for code that wants the header value to then apply it explicitly [typically as a http Authorization header] rather than using this as a request intercept.