### PR TITLE
Add Bearer authentication intercept

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/BearerTokenIntercept.java
+++ b/http-client/src/main/java/io/avaje/http/client/BearerTokenIntercept.java
@@ -1,0 +1,19 @@
+package io.avaje.http.client;
+
+/**
+ * Adds a Bearer authentication Authorization header to requests.
+ */
+public final class BearerTokenIntercept implements RequestIntercept {
+
+  private final String headerValue;
+
+  public BearerTokenIntercept(String token) {
+    this.headerValue = "Bearer " + token;
+  }
+
+  @Override
+  public void beforeRequest(HttpClientRequest request) {
+    request.header("Authorization", headerValue);
+  }
+
+}

--- a/http-client/src/test/java/io/avaje/http/client/BearerTokenInterceptTest.java
+++ b/http-client/src/test/java/io/avaje/http/client/BearerTokenInterceptTest.java
@@ -1,0 +1,25 @@
+package io.avaje.http.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BearerTokenInterceptTest {
+
+  @Test
+  void beforeRequest() {
+    // setup
+    final var intercept = new BearerTokenIntercept("api_key");
+    final var ctx = HttpClient.builder().baseUrl("junk").build();
+
+    // act
+    final HttpClientRequest request = ctx.request();
+    intercept.beforeRequest(request);
+
+    final List<String> values = request.header("Authorization");
+    assertThat(values).containsExactly("Bearer api_key");
+  }
+
+}


### PR DESCRIPTION
Currently, the documentation provides instructions on how to build a bearer token provider, which assumes that tokens are short-lived and must be refreshed after some time. However, some REST APIs offer a bearer token authentication mechanism that relies on the API key/secret instead of short-lived tokens. Since this is a somewhat common use case, and given that we also have an existing implementation for basic auth, I feel like it makes sense to have this implementation offered out of the box too.

Examples:
- [Loops.so](https://loops.so/docs/api-reference/intro#authentication-steps)
- [OpenAI](https://platform.openai.com/docs/quickstart?language-preference=curl#make-your-first-api-request)
- [Notion](https://developers.notion.com/reference/authentication)