### PR TITLE
[client] Followup #546 - put GeneratedHttpComponent into top package

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentMetaData.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentMetaData.java
@@ -28,9 +28,6 @@ final class ComponentMetaData {
   String fullName() {
     if (fullName == null) {
       String topPackage = TopPackage.of(generatedClients);
-      if (!topPackage.endsWith(".httpclient")) {
-        topPackage += ".httpclient";
-      }
       fullName = topPackage + ".GeneratedHttpComponent";
     }
     return fullName;

--- a/tests/test-client-generation/src/main/java/org/example/JunkApi.java
+++ b/tests/test-client-generation/src/main/java/org/example/JunkApi.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 @Client
-public interface JunkApi {
+interface JunkApi {
 
   @Post
   void asVoid();


### PR DESCRIPTION
Don't always put GeneratedHttpComponent into .httpclient as the client interface might NOT be public now with 546