### PR TITLE
[client] Breaking change - Rename @Client.Import(types=...) to @Client.Import(value=...).  That is, rename types -> value

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/Client.java
+++ b/http-api/src/main/java/io/avaje/http/api/Client.java
@@ -53,6 +53,6 @@ public @interface Client {
     /**
      * Client interface types that we want to generate HTTP clients for.
      */
-    Class<?>[] types();
+    Class<?>[] value();
   }
 }

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientProcessor.java
@@ -86,7 +86,7 @@ public class ClientProcessor extends AbstractProcessor {
   }
 
   private void writeForImported(Element importedElement) {
-    ImportPrism.getInstanceOn(importedElement).types().stream()
+    ImportPrism.getInstanceOn(importedElement).value().stream()
       .map(ProcessingContext::asElement)
       .filter(Objects::nonNull)
       .forEach(this::writeClient);

--- a/tests/test-client-generation/src/main/java/org/example/package-info.java
+++ b/tests/test-client-generation/src/main/java/org/example/package-info.java
@@ -1,4 +1,4 @@
-@Client.Import(types = OtherApi.class)
+@Client.Import(value = OtherApi.class)
 package org.example;
 
 import io.avaje.http.api.Client;

--- a/tests/test-client-generation/src/test/java/org/example/CommonApiTest.java
+++ b/tests/test-client-generation/src/test/java/org/example/CommonApiTest.java
@@ -12,7 +12,7 @@ import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Client.Import(types = CommonApi.class)
+@Client.Import(CommonApi.class)
 class CommonApiTest {
 
   static CommonApi client;


### PR DESCRIPTION
Now can do `@Client.Import(CustomType.class)`


--------

This is a breaking change

From:
```java
@Client.Import(types = OtherApi.class)
```

To:
```java
@Client.Import(value = OtherApi.class)
```

... and because it is value it can be now written as:

```java
@Client.Import(OtherApi.class)
```