### PR TITLE
[client] Fix test generation overriding main components

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentReader.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ComponentReader.java
@@ -7,6 +7,7 @@ import static io.avaje.http.generator.core.ProcessingContext.typeElement;
 import static java.util.stream.Collectors.toList;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -37,7 +38,6 @@ final class ComponentReader {
 
   void read() {
     for (String fqn : loadMetaInf()) {
-      System.err.println(fqn );
       final TypeElement moduleType = typeElement(fqn);
       if (moduleType != null) {
         var adapters =
@@ -67,33 +67,37 @@ final class ComponentReader {
   private Set<String> loadMetaInf() {
     var set = new HashSet<String>();
     try {
-      var main =
-          Path.of(
-              URI.create(
-                  filer()
-                      .getResource(StandardLocation.CLASS_OUTPUT, "", Constants.META_INF_COMPONENT)
-                      .toUri()
-                      .toString()
-                      .replaceFirst("java/test", "java/main")
-                      .replaceFirst("test-classes", "classes")));
-
-      final var fileObject =
-          Path.of(
-              filer()
-                  .getResource(StandardLocation.CLASS_OUTPUT, "", Constants.META_INF_COMPONENT)
-                  .toUri());
-      Files.lines(main).forEach(set::add);
-      Files.lines(fileObject).forEach(set::add);
-
-    } catch (FileNotFoundException | NoSuchFileException e) {
-      // logDebug("no services file yet");
-
-    } catch (final FilerException e) {
-      logDebug("FilerException reading services file");
-
-    } catch (final Exception e) {
+      addLines(mainMetaInfURI(), set);
+      addLines(metaInfURI(), set);
+    } catch (final IOException e) {
       logWarn("Error reading services file: " + e.getMessage());
     }
     return set;
+  }
+
+  private static void addLines(URI uri, HashSet<String> set) {
+    try (var lines = Files.lines(Path.of(uri))) {
+      lines.forEach(set::add);
+    } catch (FileNotFoundException | NoSuchFileException e) {
+      // logDebug("no services file yet");
+    } catch (final FilerException e) {
+      logDebug("FilerException reading services file");
+    } catch (Exception e) {
+      logWarn("Error reading services file: " + e.getMessage());
+    }
+  }
+
+  private static URI mainMetaInfURI() throws IOException {
+    return URI.create(
+      metaInfURI()
+        .toString()
+        .replaceFirst("java/test", "java/main")
+        .replaceFirst("test-classes", "classes"));
+  }
+
+  private static URI metaInfURI() throws IOException {
+    return filer()
+      .getResource(StandardLocation.CLASS_OUTPUT, "", Constants.META_INF_COMPONENT)
+      .toUri();
   }
 }

--- a/tests/test-client/src/test/java/example/github/Dummy.java
+++ b/tests/test-client/src/test/java/example/github/Dummy.java
@@ -1,0 +1,14 @@
+package example.github;
+
+import java.util.List;
+
+import io.avaje.http.api.Client;
+import io.avaje.http.api.Get;
+import io.avaje.http.client.HttpException;
+
+@Client
+public interface Dummy {
+
+  @Get("users/{user}/repos")
+  List<Repo> listRepos(String user, String other) throws HttpException;
+}


### PR DESCRIPTION
It seems that generating a client during src/test compilation causes clients generated in src/main to be undetected during tests.

This PR makes it so that the main src/main/META-INF/services are also detected during test compilation