### PR TITLE
Generate Test Clients during test compilation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ dependency-reduced-pom.xml
 *avaje-processors.txt
 *controllers.txt
 tests/test-sigma/io.avaje.jsonb.spi.JsonbExtension
+tests/test-sigma/*.txt
 tests/test-javalin-jsonb/*.txt
+tests/test-nima-jsonb/*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ build/
 *.Module
 dependency-reduced-pom.xml
 .DS_Store
-tests/test-sigma/avaje-processors.txt
+*avaje-processors.txt
+*controllers.txt
 tests/test-sigma/io.avaje.jsonb.spi.JsonbExtension
+tests/test-javalin-jsonb/*.txt

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/AnnotationCopier.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/AnnotationCopier.java
@@ -33,7 +33,8 @@ final class AnnotationCopier {
           || type.contains("Consumes")
           || type.contains("InstrumentServerContext")
           || type.contains("Default")
-          || type.contains("OpenAPI")) {
+          || type.contains("OpenAPI")
+          || type.contains("Valid")) {
         continue;
       }
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/AnnotationCopier.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/AnnotationCopier.java
@@ -30,7 +30,10 @@ final class AnnotationCopier {
       final var type = annotationMirror.getAnnotationType().asElement().asType().toString();
       if (!type.contains("io.avaje.http.api.")
           || type.contains("Produces")
-          || type.contains("Consumes")) {
+          || type.contains("Consumes")
+          || type.contains("InstrumentServerContext")
+          || type.contains("Default")
+          || type.contains("OpenAPI")) {
         continue;
       }
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/AnnotationCopier.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/AnnotationCopier.java
@@ -1,0 +1,141 @@
+package io.avaje.http.generator.core;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+
+final class AnnotationCopier {
+  private AnnotationCopier() {}
+
+  private static final Pattern ANNOTATION_TYPE_PATTERN = Pattern.compile("@([\\w.]+)\\.");
+
+  static String trimAnnotationString(String input) {
+    return ANNOTATION_TYPE_PATTERN.matcher(input).replaceAll("@");
+  }
+
+  static void copyAnnotations(Append writer, Element element, boolean newLines) {
+    copyAnnotations(writer, element, "", newLines);
+  }
+
+  static void copyAnnotations(Append writer, Element element, String indent, boolean newLines) {
+    for (final AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+      final var type = annotationMirror.getAnnotationType().asElement().asType().toString();
+      if (!type.contains("io.avaje.http.api.")
+          || type.contains("Produces")
+          || type.contains("Consumes")) {
+        continue;
+      }
+
+      String annotationString = toAnnotationString(indent, annotationMirror, false);
+
+      annotationString =
+          annotationString
+              .replace("io.avaje.http.api.", "")
+              .replace("value=", "")
+              .replace("(\"\")", "");
+
+      writer.append(annotationString);
+
+      if (newLines) {
+        writer.eol();
+      } else {
+        writer.append(" ");
+      }
+    }
+  }
+
+  static String toSimpleAnnotationString(AnnotationMirror annotationMirror) {
+    return trimAnnotationString(toAnnotationString("", annotationMirror, true)).substring(1);
+  }
+
+  static String toAnnotationString(
+      String indent, AnnotationMirror annotationMirror, boolean simpleEnums) {
+    final String annotationName = annotationMirror.getAnnotationType().toString();
+
+    final StringBuilder sb =
+        new StringBuilder(indent).append("@").append(annotationName).append("(");
+    boolean first = true;
+
+    for (final var entry : sortedValues(annotationMirror)) {
+      if (!first) {
+        sb.append(", ");
+      }
+      sb.append(entry.getKey().getSimpleName()).append("=");
+      writeVal(sb, entry.getValue(), simpleEnums);
+      first = false;
+    }
+
+    return sb.append(")").toString().replace("()", "");
+  }
+
+  private static List<Entry<? extends ExecutableElement, ? extends AnnotationValue>> sortedValues(
+      AnnotationMirror annotationMirror) {
+    return APContext.elements().getElementValuesWithDefaults(annotationMirror).entrySet().stream()
+        .sorted(AnnotationCopier::compareBySimpleName)
+        .collect(toList());
+  }
+
+  private static int compareBySimpleName(
+      Entry<? extends ExecutableElement, ? extends AnnotationValue> entry1,
+      Entry<? extends ExecutableElement, ? extends AnnotationValue> entry2) {
+    return entry1
+        .getKey()
+        .getSimpleName()
+        .toString()
+        .compareTo(entry2.getKey().getSimpleName().toString());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void writeVal(
+      final StringBuilder sb, final AnnotationValue annotationValue, boolean simpleEnums) {
+    final var value = annotationValue.getValue();
+    if (value instanceof List) {
+      // handle array values
+      sb.append("{");
+      boolean first = true;
+      for (final AnnotationValue listValue : (List<AnnotationValue>) value) {
+        if (!first) {
+          sb.append(", ");
+        }
+        writeVal(sb, listValue, simpleEnums);
+        first = false;
+      }
+      sb.append("}");
+
+    } else if (value instanceof VariableElement) {
+      // Handle enum values
+      final var element = (VariableElement) value;
+      final var type = element.asType();
+      final var str = simpleEnums ? element : type.toString() + "." + element;
+      sb.append(str);
+
+    } else if (value instanceof AnnotationMirror) {
+      // handle annotation values
+      final var mirror = (AnnotationMirror) value;
+      final String annotationName = mirror.getAnnotationType().toString();
+      sb.append("@").append(annotationName).append("(");
+      boolean first = true;
+
+      for (final var entry : sortedValues(mirror)) {
+        if (!first) {
+          sb.append(", ");
+        }
+        sb.append(entry.getKey().getSimpleName()).append("=");
+        writeVal(sb, entry.getValue(), simpleEnums);
+        first = false;
+      }
+      sb.append(")");
+
+    } else {
+      sb.append(annotationValue);
+    }
+  }
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
@@ -71,7 +71,6 @@ public abstract class BaseProcessor extends AbstractProcessor {
         Files.lines(txtFilePath).forEach(controllerFQNs::add);
       }
       if (APContext.isTestCompilation()) {
-        System.out.println("Trying to read: " + controllerFQNs + "from path:" + txtFilePath);
         controllerFQNs.stream().map(APContext::typeElement).forEach(this::writeClientAdapter);
       }
     } catch (IOException e) {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
@@ -189,7 +189,7 @@ public abstract class BaseProcessor extends AbstractProcessor {
       if (reader.beanType().getInterfaces().isEmpty()
           && "java.lang.Object".equals(reader.beanType().getSuperclass().toString())) {
         new TestClientWriter(reader).write();
-        clientFQNs.add(reader.beanType().getQualifiedName().toString() + "$TestAPI");
+        clientFQNs.add(reader.beanType().getQualifiedName().toString() + "TestAPI");
       }
     } catch (final IOException e) {
       logError(reader.beanType(), "Failed to write $Route class " + e);

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
@@ -4,6 +4,7 @@ import static io.avaje.http.generator.core.ProcessingContext.doc;
 import static io.avaje.http.generator.core.ProcessingContext.elements;
 import static io.avaje.http.generator.core.ProcessingContext.isOpenApiAvailable;
 import static io.avaje.http.generator.core.ProcessingContext.logError;
+import static io.avaje.http.generator.core.ProcessingContext.logWarn;
 import static io.avaje.http.generator.core.ProcessingContext.typeElement;
 import static java.util.stream.Collectors.toMap;
 
@@ -131,6 +132,13 @@ public abstract class BaseProcessor extends AbstractProcessor {
         writeControllerAdapter(reader);
       } catch (final Throwable e) {
         logError(reader.beanType(), "Failed to write $Route class " + e);
+      }
+      try {
+        if (((TypeElement) controller).getInterfaces().isEmpty()) {
+          new TestClientWriter(reader).write();
+        }
+      } catch (Exception e) {
+        logWarn(reader.beanType(), "Failed to write test class " + e);
       }
     }
   }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
@@ -4,7 +4,6 @@ import static io.avaje.http.generator.core.ProcessingContext.doc;
 import static io.avaje.http.generator.core.ProcessingContext.elements;
 import static io.avaje.http.generator.core.ProcessingContext.isOpenApiAvailable;
 import static io.avaje.http.generator.core.ProcessingContext.logError;
-import static io.avaje.http.generator.core.ProcessingContext.logWarn;
 import static io.avaje.http.generator.core.ProcessingContext.typeElement;
 import static java.util.stream.Collectors.toMap;
 
@@ -129,16 +128,16 @@ public abstract class BaseProcessor extends AbstractProcessor {
       final var reader = new ControllerReader((TypeElement) controller, contextPath);
       reader.read(true);
       try {
+
         writeControllerAdapter(reader);
-      } catch (final Throwable e) {
-        logError(reader.beanType(), "Failed to write $Route class " + e);
-      }
-      try {
-        if (((TypeElement) controller).getInterfaces().isEmpty()) {
+        TypeElement typeElement = (TypeElement) controller;
+        if (typeElement.getInterfaces().isEmpty()
+            && "java.lang.Object".equals(typeElement.getSuperclass().toString())) {
           new TestClientWriter(reader).write();
         }
-      } catch (Exception e) {
-        logWarn(reader.beanType(), "Failed to write test class " + e);
+
+      } catch (final Throwable e) {
+        logError(reader.beanType(), "Failed to write $Route class " + e);
       }
     }
   }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
@@ -131,7 +131,8 @@ public abstract class BaseProcessor extends AbstractProcessor {
 
         writeControllerAdapter(reader);
         TypeElement typeElement = (TypeElement) controller;
-        if (typeElement.getInterfaces().isEmpty()
+        if (APContext.isTestCompilation()
+            && typeElement.getInterfaces().isEmpty()
             && "java.lang.Object".equals(typeElement.getSuperclass().toString())) {
           new TestClientWriter(reader).write();
         }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/PrimitiveUtil.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/PrimitiveUtil.java
@@ -15,7 +15,8 @@ public final class PrimitiveUtil {
           "short", "Short",
           "double", "Double",
           "float", "Float",
-          "boolean", "Boolean");
+          "boolean", "Boolean",
+          "void", "Void");
 
   public static String wrap(String shortName) {
     final var wrapped = wrapperMap.get(shortName);

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
@@ -88,7 +89,12 @@ public class TestClientWriter {
   private void writeClassStart() {
     writer.append(AT_GENERATED).eol();
     writer.append("@Client(\"%s\")", reader.path()).eol();
-    writer.append("public interface %s$TestAPI {", shortName).eol().eol();
+    writer
+        .append(
+            "%sinterface %s$TestAPI {",
+            reader.beanType().getModifiers().contains(Modifier.PUBLIC) ? "public " : "", shortName)
+        .eol()
+        .eol();
   }
 
   private void writeAddRoutes() {
@@ -102,6 +108,7 @@ public class TestClientWriter {
   private void writeRoute(MethodReader method) {
     TypeMirror returnType = method.returnType();
     var isJstache = ProcessingContext.isJstacheTemplate(returnType);
+    writer.append("  ");
     AnnotationCopier.copyAnnotations(writer, method.element(), true);
 
     var returnTypeStr = PrimitiveUtil.wrap(UType.parse(returnType).shortType());
@@ -112,7 +119,7 @@ public class TestClientWriter {
     }
 
     writer.append(
-        "HttpResponse<%s> %s(", isJstache ? "String" : returnTypeStr, method.simpleName());
+        "  HttpResponse<%s> %s(", isJstache ? "String" : returnTypeStr, method.simpleName());
     boolean first = true;
     for (var param : method.params()) {
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
@@ -106,6 +106,12 @@ public class TestClientWriter {
   }
 
   private void writeRoute(MethodReader method) {
+
+    // TODO handle Contexts later
+    if (method.params().stream().anyMatch(p -> p.paramType() == ParamType.CONTEXT)) {
+      return;
+    }
+
     TypeMirror returnType = method.returnType();
     var isJstache = ProcessingContext.isJstacheTemplate(returnType);
     writer.append("  ");

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
@@ -46,7 +46,7 @@ public class TestClientWriter {
     writer =
         new Append(
             new FileWriter(
-                APContext.getBuildResource("testAPI/" + originName + "$TestAPI.txt").toFile()));
+                APContext.getBuildResource("testAPI/" + originName + "TestAPI.txt").toFile()));
   }
 
   protected String initPackageName(String originName) {
@@ -95,7 +95,7 @@ public class TestClientWriter {
     writer.append("@Client(\"%s\")", reader.path()).eol();
     writer
         .append(
-            "%sinterface %s$TestAPI {",
+            "%sinterface %sTestAPI {",
             reader.beanType().getModifiers().contains(Modifier.PUBLIC) ? "public " : "", shortName)
         .eol()
         .eol();
@@ -118,8 +118,7 @@ public class TestClientWriter {
 
     TypeMirror returnType = method.returnType();
     var isJstache = ProcessingContext.isJstacheTemplate(returnType);
-    writer.append("  ");
-    AnnotationCopier.copyAnnotations(writer, method.element(), true);
+    AnnotationCopier.copyAnnotations(writer, method.element(), "  ", true);
 
     var returnTypeStr = PrimitiveUtil.wrap(UType.parse(returnType).shortType());
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
@@ -1,0 +1,125 @@
+package io.avaje.http.generator.core;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+
+public class TestClientWriter {
+
+  private static final String AT_GENERATED = "@Generated(\"avaje-http-generator\")";
+  private final Set<String> importTypes = new TreeSet<>();
+  private final ControllerReader reader;
+  private String originName;
+  private String shortName;
+  private String packageName;
+  private String fullName;
+  private Append writer;
+
+  TestClientWriter(ControllerReader reader) throws IOException {
+
+    this.reader = reader;
+    final TypeElement origin = reader.beanType();
+    this.originName = origin.getQualifiedName().toString();
+    this.shortName = origin.getSimpleName().toString();
+    this.packageName = initPackageName(originName);
+    this.fullName = packageName + "." + shortName + "$TestAPI";
+    writer = new Append(APContext.createSourceFile(fullName, reader.beanType()).openWriter());
+  }
+
+  protected String initPackageName(String originName) {
+    final int dp = originName.lastIndexOf('.');
+    return dp > -1 ? originName.substring(0, dp) : null;
+  }
+
+  void write() {
+    writePackage();
+    writeImports();
+    writeClassStart();
+    writeAddRoutes();
+  }
+
+  protected void writePackage() {
+    if (packageName != null) {
+      writer.append("package %s;", packageName).eol().eol();
+    }
+  }
+
+  protected void writeImports() {
+    importTypes.add("java.net.http.HttpResponse");
+
+    reader
+        .methods()
+        .forEach(
+            m -> {
+              importTypes.addAll(UType.parse(m.returnType()).importTypes());
+              m.params()
+                  .forEach(
+                      p -> importTypes.addAll(UType.parse(p.element().asType()).importTypes()));
+            });
+
+    importTypes.addAll(reader.importTypes());
+
+    importTypes.removeIf(
+        i ->
+            i.startsWith("java.lang")
+                || PrimitiveUtil.wrapperMap.containsKey(i)
+                || i.contains(".") && i.substring(0, i.lastIndexOf(".")).equals(packageName));
+    for (String type : importTypes) {
+      writer.append("import %s;", type).eol();
+    }
+    writer.eol();
+  }
+
+  private void writeClassStart() {
+    writer.append(AT_GENERATED).eol();
+    writer.append("@Client(\"%s\")", reader.path()).eol();
+    writer.append("public interface %s$TestAPI {", shortName).eol().eol();
+  }
+
+  private void writeAddRoutes() {
+
+    reader.methods().stream()
+        .filter(MethodReader::isWebMethod)
+        .filter(
+            m ->
+                m.webMethod() instanceof CoreWebMethod
+                    && m.webMethod() != CoreWebMethod.ERROR
+                    && m.webMethod() != CoreWebMethod.FILTER
+                    && m.webMethod() != CoreWebMethod.OTHER)
+        .forEach(this::writeRoute);
+
+    writer.append("}").eol();
+    writer.close();
+  }
+
+  private void writeRoute(MethodReader method) {
+    TypeMirror returnType = method.returnType();
+    var isJstache = ProcessingContext.isJstacheTemplate(returnType);
+    AnnotationCopier.copyAnnotations(writer, method.element(), true);
+
+    var returnTypeStr = PrimitiveUtil.wrap(UType.parse(returnType).shortType());
+    writer.append(
+        "HttpResponse<%s> %s(", isJstache ? "String" : returnTypeStr, method.simpleName());
+    boolean first = true;
+    for (var param : method.params()) {
+
+      if (first) {
+        first = false;
+      } else {
+        writer.append(", ");
+      }
+      var type = UType.parse(param.element().asType());
+
+      AnnotationCopier.copyAnnotations(writer, param.element(), false);
+      writer.append("%s %s", type.shortType(), param.name());
+    }
+    writer.append(");");
+
+    writer.eol();
+    writer.eol();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <swagger.version>2.2.29</swagger.version>
     <jackson.version>2.14.2</jackson.version>
     <jex.version>3.0-RC10</jex.version>
-    <avaje.prisms.version>1.40</avaje.prisms.version>
+    <avaje.prisms.version>1.41</avaje.prisms.version>
     <project.build.outputTimestamp>2025-03-18T18:53:23Z</project.build.outputTimestamp>
     <module-info.shade>${project.build.directory}${file.separator}module-info.shade</module-info.shade>
   </properties>

--- a/tests/test-jex/pom.xml
+++ b/tests/test-jex/pom.xml
@@ -96,6 +96,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-http-jex-generator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-http-client-generator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -119,6 +130,11 @@
             <path>
               <groupId>io.avaje</groupId>
               <artifactId>avaje-http-jex-generator</artifactId>
+              <version>${project.version}</version>
+            </path>
+            <path>
+              <groupId>io.avaje</groupId>
+              <artifactId>avaje-http-client-generator</artifactId>
               <version>${project.version}</version>
             </path>
             <path>

--- a/tests/test-jex/src/test/java/org/example/web/HelloControllerTest.java
+++ b/tests/test-jex/src/test/java/org/example/web/HelloControllerTest.java
@@ -16,7 +16,7 @@ import io.avaje.jsonb.Json.Import;
 @Import(Violation.class)
 class HelloControllerTest extends BaseWebTest {
 
-  final static HttpClient client = client();
+  static final HttpClient client = client();
 
   @Test
   void getHello() {
@@ -27,7 +27,23 @@ class HelloControllerTest extends BaseWebTest {
   }
 
   @Test
+  void getHelloClient() {
+    final HelloDto hello = client.create(HelloControllerTestAPI.class).getHello().body();
+
+    assertEquals(42, hello.id);
+    assertEquals("rob", hello.name);
+  }
+
+  @Test
   void getPlain() {
+    final HttpResponse<String> res = client.create(HelloControllerTestAPI.class).getText();
+
+    assertEquals("something", res.body());
+    assertThat(res.headers().firstValue("content-type").orElseThrow()).startsWith("text/plain;");
+  }
+
+  @Test
+  void getPlainClient() {
     final HttpResponse<String> res = client.request().path("plain").GET().asString();
 
     assertEquals("something", res.body());

--- a/tests/test-nima/pom.xml
+++ b/tests/test-nima/pom.xml
@@ -43,6 +43,11 @@
       <artifactId>helidon-http-media-jsonb</artifactId>
       <version>${helidon.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-http-helidon-generator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
mostly resolves #584 with a few caveats

- won't generate client methods for controllers with a Context parameter
- won't generate for controllers that use API

There are some bugs to work out using this approach. It seems that during test compilation it causes the classes to get recompiled so inject complains with errors like  `No dependency provided for org.example.web.myapp.WebController on org.example.web.myapp.WebController$Route`