### PR TITLE
Fix generated openapi.json parameter names

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodParamDocBuilder.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/openapi/MethodParamDocBuilder.java
@@ -51,7 +51,7 @@ public class MethodParamDocBuilder {
 
     } else {
       Parameter param = new Parameter();
-      param.setName(varName);
+      param.setName(paramName);
       param.setDescription(javadoc.getParams().get(paramName));
 
       Schema<?> schema = ctx.toSchema(rawType, element);

--- a/tests/test-javalin-jsonb/src/main/resources/public/openapi.json
+++ b/tests/test-javalin-jsonb/src/main/resources/public/openapi.json
@@ -393,7 +393,7 @@
 						}
 					},
 					{
-						"name" : "myParam",
+						"name" : "my-param",
 						"in" : "query",
 						"schema" : {
 							"type" : "string"
@@ -779,7 +779,7 @@
 						}
 					},
 					{
-						"name" : "head",
+						"name" : "Head",
 						"in" : "header",
 						"schema" : {
 							"type" : "string"
@@ -994,21 +994,21 @@
 						}
 					},
 					{
-						"name" : "param2",
+						"name" : "q-2",
 						"in" : "query",
 						"schema" : {
 							"type" : "string"
 						}
 					},
 					{
-						"name" : "contentLength",
+						"name" : "Content-Length",
 						"in" : "header",
 						"schema" : {
 							"type" : "string"
 						}
 					},
 					{
-						"name" : "otherHeader",
+						"name" : "x-oh",
 						"in" : "header",
 						"schema" : {
 							"type" : "string"
@@ -1746,7 +1746,7 @@
 				"description" : "",
 				"parameters" : [
 					{
-						"name" : "head",
+						"name" : "Head",
 						"in" : "header",
 						"schema" : {
 							"type" : "string"

--- a/tests/test-javalin-jsonb/src/test/resources/expectedOpenApi.json
+++ b/tests/test-javalin-jsonb/src/test/resources/expectedOpenApi.json
@@ -42,21 +42,21 @@
             }
           },
           {
-            "name" : "param2",
+            "name" : "q-2",
             "in" : "query",
             "schema" : {
               "type" : "string"
             }
           },
           {
-            "name" : "contentLength",
+            "name" : "Content-Length",
             "in" : "header",
             "schema" : {
               "type" : "string"
             }
           },
           {
-            "name" : "otherHeader",
+            "name" : "x-oh",
             "in" : "header",
             "schema" : {
               "type" : "string"

--- a/tests/test-javalin/src/main/resources/public/openapi.json
+++ b/tests/test-javalin/src/main/resources/public/openapi.json
@@ -363,7 +363,7 @@
 						}
 					},
 					{
-						"name" : "myParam",
+						"name" : "my-param",
 						"in" : "query",
 						"schema" : {
 							"type" : "string"

--- a/tests/test-jex/src/main/resources/public/openapi.json
+++ b/tests/test-jex/src/main/resources/public/openapi.json
@@ -432,7 +432,7 @@
 						}
 					},
 					{
-						"name" : "myParam",
+						"name" : "my-param",
 						"in" : "query",
 						"schema" : {
 							"type" : "string"
@@ -908,7 +908,7 @@
 						}
 					},
 					{
-						"name" : "head",
+						"name" : "Head",
 						"in" : "header",
 						"schema" : {
 							"type" : "string"

--- a/tests/test-nima-jsonb/src/test/resources/expectedOpenApi.json
+++ b/tests/test-nima-jsonb/src/test/resources/expectedOpenApi.json
@@ -21,7 +21,7 @@
 		"/openapi/delete/{type}" : {
 			"delete" : {
 				"tags" : [
-					
+
 				],
 				"summary" : "",
 				"description" : "",
@@ -42,7 +42,7 @@
 						}
 					},
 					{
-						"name" : "header",
+						"name" : "Header",
 						"in" : "header",
 						"schema" : {
 							"type" : "string"
@@ -66,7 +66,7 @@
 		"/openapi/get" : {
 			"get" : {
 				"tags" : [
-					
+
 				],
 				"summary" : "Example of Open API Get (up to the first period is the summary)",
 				"description" : "When using Javalin Context only This Javadoc description is added to the generated openapi.json",
@@ -142,7 +142,7 @@
 		"/openapi/post1" : {
 			"post" : {
 				"tags" : [
-					
+
 				],
 				"summary" : "Standard Post",
 				"description" : "The Deprecated annotation adds \"deprecacted:true\" to the generated json",
@@ -191,7 +191,7 @@
 		"/openapi/put" : {
 			"put" : {
 				"tags" : [
-					
+
 				],
 				"summary" : "",
 				"description" : "",

--- a/tests/test-sigma/src/main/resources/public/openapi.json
+++ b/tests/test-sigma/src/main/resources/public/openapi.json
@@ -393,7 +393,7 @@
 						}
 					},
 					{
-						"name" : "myParam",
+						"name" : "my-param",
 						"in" : "query",
 						"schema" : {
 							"type" : "string"
@@ -779,7 +779,7 @@
 						}
 					},
 					{
-						"name" : "head",
+						"name" : "Head",
 						"in" : "header",
 						"schema" : {
 							"type" : "string"
@@ -1584,7 +1584,7 @@
 				"description" : "",
 				"parameters" : [
 					{
-						"name" : "head",
+						"name" : "Head",
 						"in" : "header",
 						"schema" : {
 							"type" : "string"


### PR DESCRIPTION
```java

@QueryParam String lastName               // -> "lastName" (no bug here, this was OK)
@QueryParam("q-2") String param2          // -> "q-2"
@Header String contentLength              // -> "Content-Length" (because headers automatic names are Init-Camel)
@Header("x-oh") String otherHeader        // -> "x-on"

```