### PR TITLE
[helidon] Bug fix for list of query parameters or form parameters when parameters is empty

### DIFF
--- a/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/NimaPlatformAdapter.java
+++ b/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/NimaPlatformAdapter.java
@@ -118,8 +118,8 @@ class NimaPlatformAdapter implements PlatformAdapter {
   @Override
   public void writeReadCollectionParameter(Append writer, ParamType paramType, String paramName) {
     switch (paramType) {
-      case QUERYPARAM -> writer.append("queryParams.all(\"%s\")", paramName);
-      case FORMPARAM -> writer.append("formParams.all(\"%s\")", paramName);
+      case QUERYPARAM -> writer.append("queryParams.all(\"%s\", () -> java.util.List.of())", paramName);
+      case FORMPARAM -> writer.append("formParams.all(\"%s\", () -> java.util.List.of())", paramName);
 
       case HEADER -> writer.append(
           "req.headers().all(\"%s\", () -> java.util.List.of())", paramName);

--- a/tests/test-nima/pom.xml
+++ b/tests/test-nima/pom.xml
@@ -48,6 +48,12 @@
       <artifactId>avaje-http-helidon-generator</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-http-client</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tests/test-nima/src/main/java/org/example/HelloController.java
+++ b/tests/test-nima/src/main/java/org/example/HelloController.java
@@ -6,6 +6,8 @@ import io.avaje.http.api.Default;
 import io.avaje.http.api.Get;
 import io.avaje.http.api.Produces;
 
+import java.util.List;
+
 @Controller
 public class HelloController {
 
@@ -32,5 +34,11 @@ public class HelloController {
   @Get("banana")
   Person getP(@BeanParam Person person) {
     return person;
+  }
+
+  @Produces("text/plain")
+  @Get("listParams")
+  String listParam(List<String> codes) {
+    return "codes:" + codes;
   }
 }

--- a/tests/test-nima/src/test/java/org/example/BaseWebTest.java
+++ b/tests/test-nima/src/test/java/org/example/BaseWebTest.java
@@ -1,0 +1,47 @@
+package org.example;
+
+import io.avaje.http.client.HttpClient;
+import io.avaje.inject.BeanScope;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRouting;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.time.Duration;
+import java.util.List;
+
+public class BaseWebTest {
+
+  static WebServer webServer;
+
+  public static String baseUrl;
+
+
+  @BeforeAll
+  public static void init() {
+    List<HttpFeature> routes = BeanScope.builder().build().list(HttpFeature.class);
+    final var builder = HttpRouting.builder();
+    routes.forEach(builder::addFeature);
+
+    webServer = WebServer.builder().addRouting(builder)
+      .port(9067)
+      .build()
+      .start();
+
+    baseUrl = "http://localhost:9067";
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    webServer.stop();
+  }
+
+  public static HttpClient client() {
+    return HttpClient.builder()
+      .baseUrl(baseUrl)
+      .requestTimeout(Duration.ofMinutes(2))
+      //.bodyAdapter(new JacksonBodyAdapter())
+      .build();
+  }
+}

--- a/tests/test-nima/src/test/java/org/example/HelloControllerTest.java
+++ b/tests/test-nima/src/test/java/org/example/HelloControllerTest.java
@@ -1,0 +1,35 @@
+package org.example;
+
+import org.junit.jupiter.api.Test;
+import java.net.http.HttpResponse;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HelloControllerTest extends BaseWebTest {
+
+  @Test
+  void listParamOne() {
+    HttpResponse<String> res = client().request()
+      .path("listParams")
+      .queryParam("codes", "123")
+      .GET()
+      .asPlainString();
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("codes:[123]");
+  }
+
+  @Test
+  void listParamMultiple() {
+    HttpResponse<String> res = client().request()
+      .path("listParams")
+      .queryParam("codes", "123")
+      .queryParam("codes", "456")
+      .GET()
+      .asPlainString();
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("codes:[123, 456]");
+  }
+}

--- a/tests/test-nima/src/test/java/org/example/HelloControllerTest.java
+++ b/tests/test-nima/src/test/java/org/example/HelloControllerTest.java
@@ -32,4 +32,15 @@ class HelloControllerTest extends BaseWebTest {
     assertThat(res.statusCode()).isEqualTo(200);
     assertThat(res.body()).isEqualTo("codes:[123, 456]");
   }
+
+  @Test
+  void listParamEmpty() {
+    HttpResponse<String> res = client().request()
+      .path("listParams")
+      .GET()
+      .asPlainString();
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("codes:[]");
+  }
 }


### PR DESCRIPTION
One or multiple params passes. Adding a test for NO parameters will fail.