### PR TITLE
[http-client] combine generated consecutive path literals

### DIFF
--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -1,10 +1,11 @@
 package io.avaje.http.generator.client;
 
-import io.avaje.http.generator.core.*;
-import io.avaje.http.generator.core.PathSegments.Segment;
+import static io.avaje.http.generator.core.ProcessingContext.isAssignable2Interface;
+import static io.avaje.http.generator.core.ProcessingContext.logError;
+import static io.avaje.http.generator.core.ProcessingContext.typeElement;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.ElementFilter;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -13,9 +14,23 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.avaje.http.generator.core.ProcessingContext.*;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+
+import io.avaje.http.generator.core.APContext;
+import io.avaje.http.generator.core.Append;
+import io.avaje.http.generator.core.BeanParamReader;
+import io.avaje.http.generator.core.ControllerReader;
+import io.avaje.http.generator.core.MethodParam;
+import io.avaje.http.generator.core.MethodReader;
+import io.avaje.http.generator.core.ParamType;
+import io.avaje.http.generator.core.PathSegments;
+import io.avaje.http.generator.core.PathSegments.Segment;
+import io.avaje.http.generator.core.ProcessingContext;
+import io.avaje.http.generator.core.RequestTimeoutPrism;
+import io.avaje.http.generator.core.UType;
+import io.avaje.http.generator.core.Util;
+import io.avaje.http.generator.core.WebMethod;
 
 /**
  * Write code to register Web route for a given controller method.
@@ -425,7 +440,7 @@ final class ClientMethodWriter {
     }
 
     // Write any remaining accumulated literals
-    if (combinedLiterals.length() > 1) {
+    if (combinedLiterals.length() > 0) {
       writer.append(".path(\"").append(combinedLiterals.toString()).append("\")");
     }
 

--- a/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
+++ b/http-generator-client/src/main/java/io/avaje/http/generator/client/ClientMethodWriter.java
@@ -425,7 +425,7 @@ final class ClientMethodWriter {
     }
 
     // Write any remaining accumulated literals
-    if (!combinedLiterals.isEmpty()) {
+    if (combinedLiterals.length() > 1) {
       writer.append(".path(\"").append(combinedLiterals.toString()).append("\")");
     }
 

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/ApiClient.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/ApiClient.java
@@ -12,4 +12,7 @@ public interface ApiClient {
 
   @Get("/mapped")
   String mapped(@Header("Accept") String accept) throws MappedException;
+
+  @Get("/consecutive/paths/{accept}/generate")
+  String consecutive(String accept);
 }

--- a/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/PrivateClient2.java
+++ b/http-generator-client/src/test/java/io/avaje/http/generator/client/clients/PrivateClient2.java
@@ -9,5 +9,4 @@ public interface PrivateClient2 {
 
   @Get("/private")
   String apiCall(@Header("Accept") String accept);
-
 }


### PR DESCRIPTION
Now will generate clients like this

```java
@Client
public interface ApiClient {
  @Get("/consecutive/paths/generate")
  String consecutive();
}
```

```java
  @Override
  public String consecutive(String accept) {
    return client.request()
      .path("consecutive/paths/generate")
      .GET()
      .asPlainString().body();
  }
```