### PR TITLE
[client] Fix HttpClient support for reading empty stream

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
@@ -585,7 +585,7 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
     final HttpResponse<Stream<String>> res = handler(HttpResponse.BodyHandlers.ofLines());
     this.httpResponse = res;
     checkResponse(res);
-    return res.body().map(bodyReader::readBody);
+    return res.body().filter(line -> !line.isEmpty()).map(bodyReader::readBody);
   }
 
   @Override

--- a/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/http-client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -272,6 +272,18 @@ class HelloControllerTest extends BaseWebTest {
   }
 
   @Test
+  void get_stream_as_when_empty() {
+    final HttpResponse<Stream<SimpleData>> res = clientContext.request()
+      .path("hello").path("streamEmpty")
+      .GET()
+      .asStream(SimpleData.class);
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    final List<SimpleData> data = res.body().collect(Collectors.toList());
+    assertThat(data).isEmpty();
+  }
+
+  @Test
   void get_stream_NotFoundException() {
     clientContext.metrics(true);
     final HttpException httpException = assertThrows(HttpException.class, () ->

--- a/http-client/src/test/java/org/example/webserver/HelloController$Route.java
+++ b/http-client/src/test/java/org/example/webserver/HelloController$Route.java
@@ -52,6 +52,11 @@ public class HelloController$Route extends AvajeJavalinPlugin {
       controller.stream(ctx);
     });
 
+    cfg.get("/hello/streamEmpty", ctx -> {
+      ctx.status(200);
+      controller.streamEmpty(ctx);
+    });
+
     cfg.get("/hello/{id}/{date}", ctx -> {
       ctx.status(200);
       final int id = asInt(ctx.pathParam("id"));

--- a/http-client/src/test/java/org/example/webserver/HelloController.java
+++ b/http-client/src/test/java/org/example/webserver/HelloController.java
@@ -63,6 +63,13 @@ class HelloController {
     context.result(content);
   }
 
+  @Get("streamEmpty")
+  void streamEmpty(Context context) {
+    // simulate x-json-stream response with empty stream
+    context.header("content-type", "application/x-json-stream");
+    context.result("\n");
+  }
+
   /**
    * Return the Hello DTO.
    *


### PR DESCRIPTION
The HttpClient uses the BodyHandlers.ofLines() but was not filtering out empty lines. These empty lines can fail the assigned body handler (e.g. json parsing error).

The fix is to filter out empty lines when reading the stream.