### PR TITLE
Support custom type mapping

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/MappedParam.java
+++ b/http-api/src/main/java/io/avaje/http/api/MappedParam.java
@@ -1,0 +1,30 @@
+package io.avaje.http.api;
+
+import static java.lang.annotation.ElementType.MODULE;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Marks a type to be mapped. */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE})
+public @interface MappedParam {
+
+  /** Factory method name used to construct the type. Empty means use a constructor */
+  String factoryMethod() default "";
+
+  @Retention(SOURCE)
+  @Target({TYPE, PACKAGE, MODULE})
+  @interface Import {
+
+    Class<?> value();
+
+    /** Factory method name used to construct the type. Empty means use a constructor */
+    String factoryMethod() default "";
+  }
+}

--- a/http-api/src/main/java/io/avaje/http/api/PathTypeConversion.java
+++ b/http-api/src/main/java/io/avaje/http/api/PathTypeConversion.java
@@ -98,6 +98,12 @@ public final class PathTypeConversion {
     }
   }
 
+  /** Convert to type. */
+  public static <T> T asType(Function<String, T> typeConversion, String value) {
+    checkNull(value);
+    return typeConversion.apply(value);
+  }
+
   /**
    * Convert to enum.
    */
@@ -288,9 +294,15 @@ public final class PathTypeConversion {
     }
   }
 
-  /**
-   * Convert to enum of the given type.
-   */
+  /** Convert to type (not nullable) */
+  public static <T> T toType(Function<String, T> typeConversion, String value) {
+    if (isNullOrEmpty(value)) {
+      return null;
+    }
+    return typeConversion.apply(value);
+  }
+
+  /** Convert to enum of the given type. */
   @SuppressWarnings({"rawtypes"})
   public static <T> Enum toEnum(Class<T> clazz, String value) {
     if (isNullOrEmpty(value)) {

--- a/http-api/src/main/java/io/avaje/http/api/PathVariable.java
+++ b/http-api/src/main/java/io/avaje/http/api/PathVariable.java
@@ -1,0 +1,21 @@
+package io.avaje.http.api;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** Marks a method parameter to be a path variable. */
+@Retention(RUNTIME)
+@Target({PARAMETER, FIELD})
+public @interface PathVariable {
+
+  /**
+   * The name of the path variable.
+   *
+   * <p>If left blank the method parameter name is used.
+   */
+  String value();
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ElementReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ElementReader.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import javax.lang.model.element.*;
 import javax.lang.model.type.TypeMirror;
 
+import io.avaje.http.generator.core.TypeMap.CustomHandler;
 import io.avaje.http.generator.core.openapi.MethodDocBuilder;
 import io.avaje.http.generator.core.openapi.MethodParamDocBuilder;
 
@@ -76,7 +77,9 @@ public class ElementReader {
     if (!contextType) {
       readAnnotations(element, defaultType);
       useValidation = useValidation();
-      HttpValidPrism.getOptionalOn(element.getEnclosingElement()).map(HttpValidPrism::groups).stream()
+      HttpValidPrism.getOptionalOn(element.getEnclosingElement())
+          .map(HttpValidPrism::groups)
+          .stream()
           .flatMap(List::stream)
           .map(TypeMirror::toString)
           .forEach(validationGroups::add);
@@ -101,8 +104,33 @@ public class ElementReader {
   }
 
   TypeHandler initTypeHandler() {
+
+    var handler = TypeMap.get(rawType);
+
+    final var typeOp =
+        Optional.ofNullable(type).or(() -> Optional.of(UType.parse(element.asType())));
+
+    var customType = typeOp.orElseThrow();
+    var actual = customType.isGeneric() ? UType.parse(customType.param0()) : customType;
+
+    if (handler == null) {
+      Optional.ofNullable(APContext.typeElement(customType.full()))
+          .flatMap(MappedParamPrism::getOptionalOn)
+          .ifPresent(p -> TypeMap.add(new CustomHandler(actual, p.factoryMethod())));
+
+      handler = TypeMap.get(rawType);
+    }
+
+    if (handler == null && ParamPrism.isPresent(element)) {
+
+      handler =
+          Optional.ofNullable(APContext.typeElement(customType.full()))
+              .flatMap(Util::stringConstructor)
+              .map(m -> new CustomHandler(actual, ""))
+              .orElse(null);
+    }
+
     if (specialParam) {
-      final var typeOp = Optional.ofNullable(type).or(() -> Optional.of(UType.parse(element.asType())));
 
       final var mainTypeEnum =
           typeOp
@@ -119,7 +147,8 @@ public class ElementReader {
       final var isMap =
           !isCollection && typeOp.filter(t -> t.mainType().startsWith("java.util.Map")).isPresent();
 
-      final var isOptional = typeOp.filter(t -> t.mainType().startsWith("java.util.Optional")).isPresent();
+      final var isOptional =
+          typeOp.filter(t -> t.mainType().startsWith("java.util.Optional")).isPresent();
 
       if (mainTypeEnum) {
         return TypeMap.enumParamHandler(typeOp.orElseThrow());
@@ -142,7 +171,7 @@ public class ElementReader {
       }
     }
 
-    return TypeMap.get(rawType);
+    return handler;
   }
 
   private boolean useValidation() {
@@ -191,6 +220,14 @@ public class ElementReader {
     if (headerParam != null) {
       this.paramName = nameFrom(headerParam.value(), Util.initcapSnake(snakeName));
       this.paramType = ParamType.HEADER;
+      this.paramDefault = null;
+      return;
+    }
+
+    final var pathVar = PathVariablePrism.getInstanceOn(element);
+    if (pathVar != null) {
+      this.paramName = nameFrom(pathVar.value(), Util.initcapSnake(snakeName));
+      this.paramType = ParamType.PATHPARAM;
       this.paramDefault = null;
       return;
     }
@@ -312,7 +349,7 @@ public class ElementReader {
   }
 
   void writeCtxGet(Append writer, PathSegments segments) {
-    if (isPlatformContext() || (paramType == ParamType.BODY && platform().isBodyMethodParam())) {
+    if (isPlatformContext() || paramType == ParamType.BODY && platform().isBodyMethodParam()) {
       // body passed as method parameter (Helidon)
       return;
     }
@@ -347,9 +384,9 @@ public class ElementReader {
         // path or matrix parameter
         final boolean requiredParam = segment.isRequired(varName);
         final String asMethod =
-            (typeHandler == null)
+            typeHandler == null
                 ? null
-                : (requiredParam) ? typeHandler.asMethod() : typeHandler.toMethod();
+                : requiredParam ? typeHandler.asMethod() : typeHandler.toMethod();
         if (asMethod != null) {
           writer.append(asMethod);
         }
@@ -362,7 +399,7 @@ public class ElementReader {
       }
     }
 
-    final String asMethod = (typeHandler == null) ? null : typeHandler.toMethod();
+    final String asMethod = typeHandler == null ? null : typeHandler.toMethod();
     if (asMethod != null) {
       writer.append(asMethod);
     }
@@ -382,7 +419,8 @@ public class ElementReader {
     } else if (hasParamDefault()) {
       platform().writeReadParameter(writer, paramType, paramName, paramDefault.get(0));
     } else {
-      final var checkNull = notNullKotlin || (paramType == ParamType.FORMPARAM && typeHandler.isPrimitive());
+      final var checkNull =
+          notNullKotlin || paramType == ParamType.FORMPARAM && typeHandler.isPrimitive();
       if (checkNull) {
         writer.append("checkNull(");
       }
@@ -398,9 +436,11 @@ public class ElementReader {
     return true;
   }
 
-  private void writeForm(Append writer, String shortType, String varName, ParamType defaultParamType) {
+  private void writeForm(
+      Append writer, String shortType, String varName, ParamType defaultParamType) {
     final TypeElement formBeanType = typeElement(rawType);
-    final BeanParamReader form = new BeanParamReader(formBeanType, varName, shortType, defaultParamType);
+    final BeanParamReader form =
+        new BeanParamReader(formBeanType, varName, shortType, defaultParamType);
     form.write(writer);
   }
 

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ParamPrism.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ParamPrism.java
@@ -1,0 +1,46 @@
+package io.avaje.http.generator.core;
+
+import java.util.Optional;
+
+import javax.lang.model.element.Element;
+
+import io.avaje.prism.GeneratePrism;
+
+@GeneratePrism(
+    value = io.avaje.http.api.PathVariable.class,
+    publicAccess = true,
+    superInterfaces = ParamPrism.class)
+@GeneratePrism(
+    value = io.avaje.http.api.QueryParam.class,
+    publicAccess = true,
+    superInterfaces = ParamPrism.class)
+@GeneratePrism(
+    value = io.avaje.http.api.Cookie.class,
+    publicAccess = true,
+    superInterfaces = ParamPrism.class)
+@GeneratePrism(
+    value = io.avaje.http.api.FormParam.class,
+    publicAccess = true,
+    superInterfaces = ParamPrism.class)
+@GeneratePrism(
+    value = io.avaje.http.api.Header.class,
+    publicAccess = true,
+    superInterfaces = ParamPrism.class)
+@GeneratePrism(
+    value = io.avaje.http.api.MatrixParam.class,
+    publicAccess = true,
+    superInterfaces = ParamPrism.class)
+public interface ParamPrism {
+
+  static boolean isPresent(Element e) {
+    return Optional.<ParamPrism>empty()
+        .or(() -> PathVariablePrism.getOptionalOn(e))
+        .or(() -> QueryParamPrism.getOptionalOn(e))
+        .or(() -> CookiePrism.getOptionalOn(e))
+        .or(() -> FormParamPrism.getOptionalOn(e))
+        .or(() -> HeaderPrism.getOptionalOn(e))
+        .or(() -> MatrixParamPrism.getOptionalOn(e))
+        .isPresent();
+  }
+
+}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/Util.java
@@ -1,18 +1,23 @@
 package io.avaje.http.generator.core;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.SimpleAnnotationValueVisitor8;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class Util {
   // whitespace not in quotes
@@ -265,5 +270,18 @@ public class Util {
       fullRoles.add(roleEnum.asType() + "." + roleEnum.getSimpleName());
       return fullRoles;
     }
+  }
+
+  static Optional<ExecutableElement> stringConstructor(TypeElement typeElement) {
+    return ElementFilter.constructorsIn(typeElement.getEnclosedElements()).stream()
+        .filter(
+            m ->
+                m.getParameters().size() == 1
+                    && m.getParameters()
+                        .get(0)
+                        .asType()
+                        .toString()
+                        .equals(String.class.getTypeName()))
+        .findAny();
   }
 }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
@@ -1,18 +1,19 @@
 /** Generate the prisms to access annotation info */
-@GeneratePrism(value = io.avaje.http.api.Controller.class, publicAccess = true, superInterfaces = WebAPIPrism.class)
-@GeneratePrism(value = io.avaje.http.api.Client.class, publicAccess = true, superInterfaces = WebAPIPrism.class)
+@GeneratePrism(
+    value = io.avaje.http.api.Controller.class,
+    publicAccess = true,
+    superInterfaces = WebAPIPrism.class)
+@GeneratePrism(
+    value = io.avaje.http.api.Client.class,
+    publicAccess = true,
+    superInterfaces = WebAPIPrism.class)
 @GeneratePrism(value = io.avaje.http.api.BeanParam.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Ignore.class, publicAccess = true)
-@GeneratePrism(value = io.avaje.http.api.QueryParam.class, publicAccess = true)
-@GeneratePrism(value = io.avaje.http.api.Cookie.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.BodyString.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Default.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Delete.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Form.class, publicAccess = true)
-@GeneratePrism(value = io.avaje.http.api.FormParam.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Get.class, publicAccess = true)
-@GeneratePrism(value = io.avaje.http.api.Header.class, publicAccess = true)
-@GeneratePrism(value = io.avaje.http.api.MatrixParam.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Patch.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Path.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Post.class, publicAccess = true)
@@ -22,14 +23,24 @@
 @GeneratePrism(value = io.avaje.http.api.Filter.class)
 @GeneratePrism(value = io.avaje.http.api.InstrumentServerContext.class)
 @GeneratePrism(value = io.avaje.http.api.ExceptionHandler.class)
+@GeneratePrism(value = io.avaje.http.api.MappedParam.class)
+@GeneratePrism(value = io.avaje.http.api.MappedParam.Import.class, name = "MapImportPrism")
 @GeneratePrism(value = io.swagger.v3.oas.annotations.OpenAPIDefinition.class, publicAccess = true)
 @GeneratePrism(value = io.swagger.v3.oas.annotations.Operation.class, publicAccess = true)
 @GeneratePrism(value = io.swagger.v3.oas.annotations.tags.Tag.class, publicAccess = true)
 @GeneratePrism(value = io.swagger.v3.oas.annotations.tags.Tags.class, publicAccess = true)
-@GeneratePrism(value = io.swagger.v3.oas.annotations.security.SecurityScheme.class, publicAccess = true)
-@GeneratePrism(value = io.swagger.v3.oas.annotations.security.SecuritySchemes.class, publicAccess = true)
-@GeneratePrism(value = io.swagger.v3.oas.annotations.security.SecurityRequirement.class, publicAccess = true)
-@GeneratePrism(value = io.swagger.v3.oas.annotations.security.SecurityRequirements.class, publicAccess = true)
+@GeneratePrism(
+    value = io.swagger.v3.oas.annotations.security.SecurityScheme.class,
+    publicAccess = true)
+@GeneratePrism(
+    value = io.swagger.v3.oas.annotations.security.SecuritySchemes.class,
+    publicAccess = true)
+@GeneratePrism(
+    value = io.swagger.v3.oas.annotations.security.SecurityRequirement.class,
+    publicAccess = true)
+@GeneratePrism(
+    value = io.swagger.v3.oas.annotations.security.SecurityRequirements.class,
+    publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.OpenAPIResponse.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.OpenAPIResponses.class, publicAccess = true)
 @GeneratePrism(value = io.swagger.v3.oas.annotations.Hidden.class, publicAccess = true)

--- a/tests/test-nima-jsonb/src/main/java/org/example/TestController.java
+++ b/tests/test-nima-jsonb/src/main/java/org/example/TestController.java
@@ -1,7 +1,10 @@
 package org.example;
 
 import java.io.InputStream;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import io.avaje.http.api.BodyString;
 import io.avaje.http.api.Controller;
@@ -12,6 +15,7 @@ import io.avaje.http.api.Form;
 import io.avaje.http.api.FormParam;
 import io.avaje.http.api.Get;
 import io.avaje.http.api.InstrumentServerContext;
+import io.avaje.http.api.MappedParam;
 import io.avaje.http.api.Path;
 import io.avaje.http.api.Post;
 import io.avaje.http.api.Produces;
@@ -161,5 +165,46 @@ public class TestController {
   @Get("/maybeList/{maybe}")
   List<Person> maybePersonList(boolean maybe) {
     return maybe ? List.of(new Person(9, "hi")) : null; // Collections.emptyList();
+  }
+
+  @MappedParam
+  @MappedParam.Import(Simple2.class)
+  record Simple(String name) {}
+
+  record Simple2(String name) {}
+
+  @Form
+  @Get("/typeForm")
+  String typeForm(Simple s, Simple2 type) {
+    return type.name();
+  }
+
+  @MappedParam(factoryMethod = "build")
+  record Static(String name) {
+    static Static build(String name) {
+      return null;
+    }
+  }
+
+  @Get("/typeFormParam")
+  String typeFormParam(@FormParam String s, @FormParam Static type) {
+    return type.name();
+  }
+
+  @Get("/typeQuery")
+  String typeQuery(@QueryParam @Default("FFA") Static type) {
+    return type.name();
+  }
+
+  @Get("/typeQuery2")
+  String typeMultiQuery(@QueryParam @Default({"FFA", "PROXY"}) Set<Simple> type) {
+    return type.toString();
+  }
+
+  record Implied(String name) {}
+
+  @Post("/typeQueryImplied")
+  String typeQueryImplied(String s, @QueryParam Implied type) {
+    return type.name();
   }
 }


### PR DESCRIPTION
Adds a new annotation to register/import type handlers for custom types.

I'm not sure about the annotation name.


- adds new annotation for mapping
- if the type has no mapping and we know it is not a body (it's annotated by `@Header` or something) and it also have a constructor that takes a string, a mapping is generated
- you can import external types
- you can use static factory methods 

you can use it like:

```java

  @MappedParam
  @MappedParam.Import(Simple2.class)
  record Simple(String name) {}

  record Simple2(String name) {}

  @Form
  @Get("/typeForm")
  String typeForm(Simple s, Simple2 type) {
    return type.name();
  }

  @MappedParam(factoryMethod = "build")
  record Static(String name) {
    static Static build(String name) {
      return null;
    }
  }

  @Get("/typeFormParam")
  String typeFormParam(@FormParam String s, @FormParam Static type) {
    return type.name();
  }

  @Get("/typeQuery2")
  String typeMultiQuery(@QueryParam @Default({"FFA", "PROXY"}) Set<Simple> type) {
    return type.toString();
  }

  record Implied(String name) {}

  @Post("/typeQueryImplied")
  String typeQueryImplied(String s, @QueryParam Implied type) {
    return type.name();
  }
```

resolves #640  and https://github.com/avaje/avaje-http/issues/539