### PR TITLE
Throw an exception if trying to send a request on a closed client

### DIFF
--- a/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/http-client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -88,11 +88,9 @@ final class DHttpClientContext implements HttpClient, SpiHttpClient {
 
   @Override
   public HttpClientRequest request() {
-
     if (closed) {
       throw new IllegalStateException("HttpClient is closed");
     }
-
     return retryHandler == null
       ? new DHttpClientRequest(this, requestTimeout)
       : new DHttpClientRequestWithRetry(this, requestTimeout, retryHandler);


### PR DESCRIPTION
A guy was accidently closing the client before he sent the request and the error message didn't make much sense.