### PR TITLE
Minimise types registered with avaje-inject for generated Routers

### DIFF
--- a/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
+++ b/http-generator-helidon/src/main/java/io/avaje/http/generator/helidon/nima/ControllerWriter.java
@@ -118,6 +118,7 @@ class ControllerWriter extends BaseControllerWriter {
   private void writeClassStart() {
     writer.append(AT_GENERATED).eol();
     writer.append(diAnnotation()).eol();
+    writer.append("@io.avaje.inject.BeanTypes({%s$Route.class, HttpFeature.class})", shortName).eol();
     writer.append("public final class %s$Route implements HttpFeature {", shortName).eol().eol();
 
     var controllerName = "controller";

--- a/http-generator-jex/src/main/java/io/avaje/http/generator/jex/ControllerWriter.java
+++ b/http-generator-jex/src/main/java/io/avaje/http/generator/jex/ControllerWriter.java
@@ -82,7 +82,8 @@ class ControllerWriter extends BaseControllerWriter {
   private void writeClassStart() {
     writer.append(AT_GENERATED).eol();
     writer.append(diAnnotation()).eol();
-    writer.append("public final class ").append(shortName).append("$Route implements Routing.HttpService {").eol().eol();
+    writer.append("@io.avaje.inject.BeanTypes({%s$Route.class, Routing.HttpService.class})", shortName).eol();
+    writer.append("public final class %s$Route implements Routing.HttpService {", shortName).eol().eol();
 
     String controllerName = "controller";
     String controllerType = shortName;


### PR DESCRIPTION
Use `@BeanTypes` on the generated routers for Jex and Helidon to reduce the number of types registered with avaje-inject.

Helidon in particular, without this generates:

```
builder.isBeanAbsent(FooController$Route.class, HttpFeature.class,
   TYPE_SupplierHttpFeature, Supplier.class, ServerLifecycle.class)
```
and with this change we get:
```
builder.isBeanAbsent(FooController$Route.class, HttpFeature.class)
```