### PR TITLE
Mark the plugin as thread-safe

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/avaje/http/maven/openapi/OpenApiMojo.java
+++ b/openapi-maven-plugin/src/main/java/io/avaje/http/maven/openapi/OpenApiMojo.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
-@Mojo(name = "openapi", defaultPhase = LifecyclePhase.PROCESS_CLASSES)
+@Mojo(name = "openapi", defaultPhase = LifecyclePhase.PROCESS_CLASSES, threadSafe = true)
 public class OpenApiMojo extends AbstractMojo {
 
   /**


### PR DESCRIPTION
Resolves #699. This is safe because, according to the maven wiki (source: https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) we only need to worry about:
 * Static fields/variables
 * Dependencies
 * Singletons

Which this plugin has none of.