### PR TITLE
Add `@Body` to resolve ambiguous scalar/collection parameter inferenc…

### DIFF
--- a/http-api/src/main/java/io/avaje/http/api/Body.java
+++ b/http-api/src/main/java/io/avaje/http/api/Body.java
@@ -1,0 +1,32 @@
+package io.avaje.http.api;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a controller method parameter to be read from the request body.
+ * <p>
+ * Use this to explicitly force body binding when a parameter could otherwise be interpreted as a
+ * query parameter (or form parameter when the method is marked {@link Form}). This is commonly
+ * used for scalar values and scalar collections such as {@code String} and {@code List<Long>}.
+ * </p>
+ *
+ * <h4>Example</h4>
+ *
+ * <pre>{@code
+ * @Controller
+ * class ProductController {
+ *
+ *   @Post("/products/filter")
+ *   String filter(@Body List<String> codes) {
+ *     return "codes:" + codes;
+ *   }
+ * }
+ * }</pre>
+ */
+@Retention(SOURCE)
+@Target(PARAMETER)
+public @interface Body {}

--- a/http-api/src/main/java/io/avaje/http/api/BodyString.java
+++ b/http-api/src/main/java/io/avaje/http/api/BodyString.java
@@ -7,9 +7,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Marks a controller string method parameter to be a string body. Use when you expect to receive an
- * application/text or similar body request.
+ * Marks a controller string method parameter to be a string body.
+ * <p>
+ * Use when you expect to receive an application/text or similar body request.
+ * </p>
+ *
+ * @deprecated Use {@link Body} instead. Migrate existing {@code @BodyString String} parameters to
+ *     {@code @Body String}.
  */
+@Deprecated(since = "3.9")
 @Retention(SOURCE)
 @Target(PARAMETER)
 public @interface BodyString {}

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ElementReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ElementReader.java
@@ -184,6 +184,10 @@ public class ElementReader {
     if (defaultVal != null) {
       this.paramDefault = defaultVal.value();
     }
+    if (BodyPrism.isPresent(element)) {
+      this.paramType = ParamType.BODY;
+      return;
+    }
     if (FormPrism.isPresent(element)) {
       this.paramType = ParamType.FORM;
       return;
@@ -386,7 +390,7 @@ public class ElementReader {
       }
     }
 
-    final String asMethod = typeHandler == null ? null : typeHandler.toMethod();
+    final String asMethod = paramType == ParamType.BODY || typeHandler == null ? null : typeHandler.toMethod();
     if (asMethod != null) {
       writer.append(asMethod);
     }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/package-info.java
@@ -5,6 +5,7 @@
 @GeneratePrism(value = io.avaje.http.api.Client.class, publicAccess = true, superInterfaces = WebAPIPrism.class)
 @GeneratePrism(value = io.avaje.http.api.BeanParam.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Ignore.class, publicAccess = true)
+@GeneratePrism(value = io.avaje.http.api.Body.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.BodyString.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Default.class, publicAccess = true)
 @GeneratePrism(value = io.avaje.http.api.Delete.class, publicAccess = true)

--- a/http-generator-jex/src/main/java/io/avaje/http/generator/jex/JexAdapter.java
+++ b/http-generator-jex/src/main/java/io/avaje/http/generator/jex/JexAdapter.java
@@ -49,31 +49,15 @@ class JexAdapter implements PlatformAdapter {
 
   public static String writeJsonbType(UType type) {
     var writer = new StringBuilder();
-    switch (type.mainType()) {
-      case "java.util.List":
-        writeType(type.paramRaw(), writer);
-        writer.append(".list()");
-        break;
-      case "java.util.Set":
-        writeType(type.paramRaw(), writer);
-        writer.append(".set()");
-        break;
-      case "java.util.Map":
-        writeType(type.paramRaw(), writer);
-        writer.append(".map()");
-        break;
-      case "java.util.stream.Stream":
-        writeType(type.paramRaw(), writer);
-        writer.append(".stream()");
-        break;
-      default: {
-        if (type.mainType().contains("java.util")) {
-          throw new UnsupportedOperationException(
-            "Only java.util Map, Set, List and Stream are supported JsonB Controller Collection Types");
-        }
-        writeType(type, writer);
-      }
+    if (type.mainType().contains("java.util")
+      && !type.mainType().startsWith("java.util.List")
+      && !type.mainType().startsWith("java.util.Set")
+      && !type.mainType().startsWith("java.util.Map")
+      && !type.mainType().startsWith("java.util.stream.Stream")) {
+      throw new UnsupportedOperationException(
+        "Only java.util Map, Set, List and Stream are supported JsonB Controller Collection Types");
     }
+    writeType(type, writer);
     return writer.toString();
   }
 

--- a/tests/test-jex/src/main/java/org/example/web/TestController.java
+++ b/tests/test-jex/src/main/java/org/example/web/TestController.java
@@ -1,7 +1,9 @@
 package org.example.web;
 
 import java.util.Set;
+import java.util.List;
 
+import io.avaje.http.api.Body;
 import io.avaje.http.api.BodyString;
 import io.avaje.http.api.Controller;
 import io.avaje.http.api.Default;
@@ -40,8 +42,23 @@ public class TestController {
     return type.name();
   }
 
+  @Post("/listBody")
+  String listBody(@Body List<String> codes) {
+    return codes.toString();
+  }
+
   @Options("/strBody")
   String strBody(@BodyString String body, Context ctx) {
+    return body;
+  }
+
+  @Post("/strBodyStringPost")
+  String strBodyStringPost(@BodyString String body) {
+    return body;
+  }
+
+  @Post("/strBodyBodyPost")
+  String strBodyBodyPost(@Body String body) {
     return body;
   }
 

--- a/tests/test-jex/src/main/resources/public/openapi.json
+++ b/tests/test-jex/src/main/resources/public/openapi.json
@@ -1537,6 +1537,41 @@
 				}
 			}
 		},
+		"/test/listBody" : {
+			"post" : {
+				"tags" : [
+					
+				],
+				"summary" : "",
+				"description" : "",
+				"requestBody" : {
+					"content" : {
+						"application/json" : {
+							"schema" : {
+								"type" : "array",
+								"items" : {
+									"type" : "string",
+									"nullable" : false
+								}
+							}
+						}
+					},
+					"required" : true
+				},
+				"responses" : {
+					"201" : {
+						"description" : "",
+						"content" : {
+							"application/json" : {
+								"schema" : {
+									"type" : "string"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/test/paramMulti" : {
 			"get" : {
 				"tags" : [
@@ -1559,6 +1594,68 @@
 				],
 				"responses" : {
 					"200" : {
+						"description" : "",
+						"content" : {
+							"application/json" : {
+								"schema" : {
+									"type" : "string"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/test/strBodyBodyPost" : {
+			"post" : {
+				"tags" : [
+					
+				],
+				"summary" : "",
+				"description" : "",
+				"requestBody" : {
+					"content" : {
+						"application/text" : {
+							"schema" : {
+								"type" : "string"
+							}
+						}
+					},
+					"required" : true
+				},
+				"responses" : {
+					"201" : {
+						"description" : "",
+						"content" : {
+							"application/json" : {
+								"schema" : {
+									"type" : "string"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/test/strBodyStringPost" : {
+			"post" : {
+				"tags" : [
+					
+				],
+				"summary" : "",
+				"description" : "",
+				"requestBody" : {
+					"content" : {
+						"application/text" : {
+							"schema" : {
+								"type" : "string"
+							}
+						}
+					},
+					"required" : true
+				},
+				"responses" : {
+					"201" : {
 						"description" : "",
 						"content" : {
 							"application/json" : {

--- a/tests/test-jex/src/test/java/org/example/web/HelloControllerTest.java
+++ b/tests/test-jex/src/test/java/org/example/web/HelloControllerTest.java
@@ -221,4 +221,38 @@ class HelloControllerTest extends BaseWebTest {
     assertThat(res.statusCode()).isEqualTo(200);
   }
 
+  @Test
+  void postListBody() {
+    HttpResponse<String> res = client.request()
+      .path("test/listBody")
+      .body("[\"123\",\"456\"]")
+      .POST()
+      .asString();
+
+    assertThat(res.statusCode()).isEqualTo(201);
+    assertThat(res.body()).isEqualTo("[123, 456]");
+  }
+
+  @Test
+  void postStringBody_bodyAndBodyStringEquivalent() {
+    final var payload = "{\"key\":42}";
+
+    HttpResponse<String> bodyStringRes = client.request()
+      .path("test/strBodyStringPost")
+      .body(payload)
+      .POST()
+      .asString();
+
+    HttpResponse<String> bodyRes = client.request()
+      .path("test/strBodyBodyPost")
+      .body(payload)
+      .POST()
+      .asString();
+
+    assertThat(bodyStringRes.statusCode()).isEqualTo(201);
+    assertThat(bodyRes.statusCode()).isEqualTo(201);
+    assertThat(bodyStringRes.body()).isEqualTo(payload);
+    assertThat(bodyRes.body()).isEqualTo(payload);
+  }
+
 }

--- a/tests/test-nima-jsonb/src/main/java/org/example/TestController.java
+++ b/tests/test-nima-jsonb/src/main/java/org/example/TestController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.avaje.http.api.Body;
 import io.avaje.http.api.BodyString;
 import io.avaje.http.api.Controller;
 import io.avaje.http.api.Default;
@@ -92,6 +93,11 @@ public class TestController {
 
   @Post("/strBody")
   String strBody(@BodyString String body) {
+    return body;
+  }
+
+  @Post("/strBodyBody")
+  String strBodyBody(@Body String body) {
     return body;
   }
 

--- a/tests/test-nima-jsonb/src/test/java/org/example/TestControllerTest.java
+++ b/tests/test-nima-jsonb/src/test/java/org/example/TestControllerTest.java
@@ -66,6 +66,28 @@ class TestControllerTest {
   }
 
   @Test
+  void strBody_bodyAndBodyStringEquivalent() {
+    final var payload = "{\"key\":42}";
+
+    HttpResponse<String> bodyStringRes = client.request()
+      .path("test/strBody")
+      .body(payload)
+      .POST()
+      .asString();
+
+    HttpResponse<String> bodyRes = client.request()
+      .path("test/strBodyBody")
+      .body(payload)
+      .POST()
+      .asString();
+
+    assertThat(bodyStringRes.statusCode()).isEqualTo(201);
+    assertThat(bodyRes.statusCode()).isEqualTo(201);
+    assertThat(bodyStringRes.body()).isEqualTo(payload);
+    assertThat(bodyRes.body()).isEqualTo(payload);
+  }
+
+  @Test
   void strBody3() {
     HttpResponse<String> res = client.request()
       .path("test/strBody3")

--- a/tests/test-nima/src/main/java/org/example/HelloController.java
+++ b/tests/test-nima/src/main/java/org/example/HelloController.java
@@ -1,9 +1,11 @@
 package org.example;
 
 import io.avaje.http.api.BeanParam;
+import io.avaje.http.api.Body;
 import io.avaje.http.api.Controller;
 import io.avaje.http.api.Default;
 import io.avaje.http.api.Get;
+import io.avaje.http.api.Post;
 import io.avaje.http.api.Produces;
 
 import java.util.List;
@@ -39,6 +41,12 @@ public class HelloController {
   @Produces("text/plain")
   @Get("listParams")
   String listParam(List<String> codes) {
+    return "codes:" + codes;
+  }
+
+  @Produces("text/plain")
+  @Post("postListParams")
+  String postListParams(@Body List<String> codes) {
     return "codes:" + codes;
   }
 }

--- a/tests/test-nima/src/test/java/org/example/HelloControllerTest.java
+++ b/tests/test-nima/src/test/java/org/example/HelloControllerTest.java
@@ -43,4 +43,16 @@ class HelloControllerTest extends BaseWebTest {
     assertThat(res.statusCode()).isEqualTo(200);
     assertThat(res.body()).isEqualTo("codes:[]");
   }
+
+  @Test
+  void postListParams_body() {
+    HttpResponse<String> res = client().request()
+      .path("postListParams")
+      .body("[\"123\",\"456\"]")
+      .POST()
+      .asPlainString();
+
+    assertThat(res.statusCode()).isEqualTo(201);
+    assertThat(res.body()).isEqualTo("codes:[123, 456]");
+  }
 }


### PR DESCRIPTION
…e. For example, `List<String>` being treated as query params instead of request body.

This new `@Body` effectively replaces and deprecates the existing `@BodyString`, as it handles String type but also the other scalar types and collections of scalar types. Code should migrate to use `@Body`.

This also includes a fix to the generator behavior for explicit BODY collections. ElementReader now avoids applying query/form collection conversion wrappers to BODY params. That is, incorrect generated code when @Body is used on collection/scalar-container types.

Example:

```java
  @Post("postListParams")
  String postListParams(@Body List<String> codes) {
    return "codes:" + codes;
  }
```
... when we want `List<String> codes` via request body and NOT [inferred as] query parameters.