### PR TITLE
Fix in matching interface method to implementation with TYPE_USE annotations

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerReader.java
@@ -181,7 +181,22 @@ public final class ControllerReader {
   }
 
   private boolean matchMethod(ExecutableElement interfaceMethod, ExecutableElement element) {
-    return interfaceMethod.toString().equals(element.toString());
+    if (!interfaceMethod.getSimpleName().equals(element.getSimpleName())) {
+      return false;
+    }
+    final var interfaceParams = interfaceMethod.getParameters();
+    final var elementParams = element.getParameters();
+    if (interfaceParams.size() != elementParams.size()) {
+      return false;
+    }
+    // Compare by parameter type ignoring (type-use) annotations
+    final var types = APContext.types();
+    for (int i = 0; i < interfaceParams.size(); i++) {
+      if (!types.isSameType(interfaceParams.get(i).asType(), elementParams.get(i).asType())) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private boolean initHtml() {

--- a/tests/test-javalin/src/main/java/org/example/myapp/web/BarController.java
+++ b/tests/test-javalin/src/main/java/org/example/myapp/web/BarController.java
@@ -22,6 +22,11 @@ public class BarController implements BarInterface {
   }
 
   @Override
+  public List<Bar> search(String code) {
+    return new ArrayList<>();
+  }
+
+  @Override
   public String barMessage() {
     return "Hello";
   }

--- a/tests/test-javalin/src/main/java/org/example/myapp/web/BarInterface.java
+++ b/tests/test-javalin/src/main/java/org/example/myapp/web/BarInterface.java
@@ -3,6 +3,7 @@ package org.example.myapp.web;
 import io.avaje.http.api.*;
 import io.swagger.v3.oas.annotations.links.Link;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -15,6 +16,10 @@ public interface BarInterface {
 
   @Get("/find/:code")
   List<Bar> findByCode(String code);
+
+  // A TYPE_USE @Nullable on this query parameter
+  @Get("/search/items")
+  List<Bar> search(@QueryParam @Nullable String code);
 
   @Get
   @Produces(MediaType.TEXT_PLAIN)

--- a/tests/test-javalin/src/main/resources/public/openapi.json
+++ b/tests/test-javalin/src/main/resources/public/openapi.json
@@ -68,6 +68,40 @@
 				}
 			}
 		},
+		"/bars/search/items" : {
+			"get" : {
+				"tags" : [
+					
+				],
+				"summary" : "",
+				"description" : "",
+				"parameters" : [
+					{
+						"name" : "code",
+						"in" : "query",
+						"schema" : {
+							"type" : "string"
+						}
+					}
+				],
+				"responses" : {
+					"200" : {
+						"description" : "",
+						"content" : {
+							"application/json" : {
+								"schema" : {
+									"type" : "array",
+									"items" : {
+										"$ref" : "#/components/schemas/Bar",
+										"nullable" : false
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/bars/{id}" : {
 			"get" : {
 				"tags" : [

--- a/tests/test-javalin/src/test/java/org/example/myapp/BarControllerTest.java
+++ b/tests/test-javalin/src/test/java/org/example/myapp/BarControllerTest.java
@@ -1,7 +1,11 @@
 package org.example.myapp;
 
+import io.avaje.http.client.HttpClient;
 import org.example.myapp.web.Bar;
 import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpResponse;
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +42,21 @@ class BarControllerTest extends BaseWebTest {
       .get(baseUrl + "/bars/find/mycode")
       .then()
       .statusCode(200);
+  }
+
+  @Test
+  void search() {
+    // The interface with @QueryParam @Nullable String code (TYPE_USE @Nullable);
+    // the BarController @Override omits @Nullable. The route must still be generated.
+    HttpClient client = client();
+    HttpResponse<List<Bar>> res = client.request()
+      .path("bars").path("search").path("items")
+      .queryParam("code", "abc")
+      .GET()
+      .asList(Bar.class);
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEmpty();
   }
 
 }


### PR DESCRIPTION
So an interface method that includes JSpecify `@Nullable`, doesn't match to the implementation that didn't also have the annotation as the existing matching is just a `toString()`.

Change `matchMethod()` to instead match irrespective of type use annotations. Instead match on each parameter type without annotations.

The impact of this bug currently is that the implementation method does not match the interface, and so the route does not get registered, and hence a test would get a 404. The added test confirms the route is registered.