### PR TITLE
Add TestAPI client generation for "Contract-First" controllers

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/BaseProcessor.java
@@ -239,10 +239,15 @@ public abstract class BaseProcessor extends AbstractProcessor {
 
   private void writeClientAdapter(ControllerReader reader) {
     try {
-      if (reader.beanType().getInterfaces().isEmpty()
-          && "java.lang.Object".equals(reader.beanType().getSuperclass().toString())
-          && new TestClientWriter(reader).write()) {
-        clientFQNs.add(reader.beanType().getQualifiedName().toString() + "TestAPI");
+      final var beanType = reader.beanType();
+      final boolean plainController =
+        beanType.getInterfaces().isEmpty()
+          && "java.lang.Object".equals(beanType.getSuperclass().toString());
+      // contract-first: the controller implements an annotated (@Path/@Client/@Controller)
+      // interface that declares the route mappings - still generate a test client for it.
+      final boolean contractFirst = !reader.interfaces().isEmpty();
+      if ((plainController || contractFirst) && new TestClientWriter(reader).write()) {
+        clientFQNs.add(beanType.getQualifiedName() + "TestAPI");
       }
     } catch (final IOException e) {
       logError(reader.beanType(), "Failed to write $Route class " + e);

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ControllerReader.java
@@ -232,6 +232,15 @@ public final class ControllerReader {
     return beanType;
   }
 
+  /**
+   * The {@code @Path}/{@code @Client}/{@code @Controller} annotated interfaces implemented by
+   * this controller. Non-empty for a contract-first controller whose route mappings are
+   * declared on the implemented interface rather than on the controller methods directly.
+   */
+  public List<TypeElement> interfaces() {
+    return interfaces;
+  }
+
   public boolean isDocHidden() {
     return docHidden;
   }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
@@ -521,6 +521,31 @@ public class MethodReader {
     return element;
   }
 
+  /**
+   * The element that declares the HTTP method annotations ({@code @Get} etc). Normally this
+   * is the controller method itself, but for a contract-first controller (one implementing an
+   * annotated interface) the route annotations live on the overridden interface method rather
+   * than on the controller's {@code @Override}. Returns that interface method when so.
+   */
+  public ExecutableElement annotatedElement() {
+    if (hasWebMethodAnnotation(element)) {
+      return element;
+    }
+    return superMethods.stream()
+        .filter(MethodReader::hasWebMethodAnnotation)
+        .findFirst()
+        .orElse(element);
+  }
+
+  private static boolean hasWebMethodAnnotation(Element element) {
+    return GetPrism.getOptionalOn(element).isPresent()
+        || PostPrism.getOptionalOn(element).isPresent()
+        || PutPrism.getOptionalOn(element).isPresent()
+        || PatchPrism.getOptionalOn(element).isPresent()
+        || DeletePrism.getOptionalOn(element).isPresent()
+        || QueryPrism.getOptionalOn(element).isPresent();
+  }
+
   public String exceptionShortName() {
     return exceptionShortName;
   }

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/TestClientWriter.java
@@ -120,7 +120,12 @@ public class TestClientWriter {
 
     TypeMirror returnType = method.returnType();
     var isJstache = ProcessingContext.isJstacheTemplate(returnType);
-    AnnotationCopier.copyAnnotations(writer, method.element(), "  ", true);
+
+    // For a contract-first controller the route annotations (@Get, @QueryParam, ...) live on the
+    // implemented interface method, not on the controller's @Override - copy them from there.
+    var annotated = method.annotatedElement();
+    var annotatedParams = annotated.getParameters();
+    AnnotationCopier.copyAnnotations(writer, annotated, "  ", true);
 
     var returnTypeStr = PrimitiveUtil.wrap(UType.parse(returnType).shortType());
 
@@ -132,7 +137,9 @@ public class TestClientWriter {
     writer.append(
         "  HttpResponse<%s> %s(", isJstache ? "String" : returnTypeStr, method.simpleName());
     boolean first = true;
-    for (var param : method.params()) {
+    var methodParams = method.params();
+    for (int i = 0; i < methodParams.size(); i++) {
+      var param = methodParams.get(i);
 
       if (first) {
         first = false;
@@ -141,7 +148,8 @@ public class TestClientWriter {
       }
       var type = UType.parse(param.element().asType());
 
-      AnnotationCopier.copyAnnotations(writer, param.element(), false);
+      var annotationSource = i < annotatedParams.size() ? annotatedParams.get(i) : param.element();
+      AnnotationCopier.copyAnnotations(writer, annotationSource, false);
       writer.append("%s %s", type.shortType(), param.name());
     }
     writer.append(");");

--- a/tests/test-client-generation/src/test/java/org/example/CommonApiTest.java
+++ b/tests/test-client-generation/src/test/java/org/example/CommonApiTest.java
@@ -3,10 +3,12 @@ package org.example;
 import io.avaje.http.api.Client;
 import io.avaje.http.client.HttpClient;
 import io.avaje.http.client.JacksonBodyAdapter;
+import org.example.server.CommonControllerTestAPI;
 import org.example.server.Main;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.net.http.HttpResponse;
 import java.time.LocalDate;
 import java.util.Random;
 
@@ -15,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Client.Import(CommonApi.class)
 class CommonApiTest {
 
+  static HttpClient clientContext;
   static CommonApi client;
 
   @BeforeAll
@@ -23,7 +26,7 @@ class CommonApiTest {
     final int port = new Random().nextInt(1000) + 10_000;
     Main.start(port);
 
-    final HttpClient clientContext = HttpClient.builder()
+    clientContext = HttpClient.builder()
       .baseUrl("http://localhost:" + port)
       .bodyAdapter(new JacksonBodyAdapter())
       .build();
@@ -50,5 +53,30 @@ class CommonApiTest {
 
     final String result2 = client.p2(44, "bar", null, true);
     assertThat(result2).isEqualTo("p2[44;bar; after:null more:true]");
+  }
+
+  @Test
+  void testApi_generatedForContractFirstController_returnsHttpResponse() {
+    // CommonController implements the @Path/@Get annotated CommonApi interface (contract-first),
+    // so the generated CommonControllerTestAPI exposes the full HttpResponse (status + headers).
+    final CommonControllerTestAPI testApi = clientContext.create(CommonControllerTestAPI.class);
+
+    final HttpResponse<String> hello = testApi.hello();
+    assertThat(hello.statusCode()).isEqualTo(200);
+    assertThat(hello.body()).isEqualTo("hello world");
+
+    final HttpResponse<String> name = testApi.name("foo");
+    assertThat(name.statusCode()).isEqualTo(200);
+    assertThat(name.body()).isEqualTo("name[foo]");
+
+    // query params (@QueryParam names copied from the interface) and path params
+    final LocalDate date = LocalDate.of(2021, 6, 24);
+    final HttpResponse<String> p2 = testApi.p2(42, "foo", date, false);
+    assertThat(p2.statusCode()).isEqualTo(200);
+    assertThat(p2.body()).isEqualTo("p2[42;foo; after:2021-06-24 more:false]");
+
+    final HttpResponse<String> p2NullQuery = testApi.p2(44, "bar", null, true);
+    assertThat(p2NullQuery.statusCode()).isEqualTo(200);
+    assertThat(p2NullQuery.body()).isEqualTo("p2[44;bar; after:null more:true]");
   }
 }


### PR DESCRIPTION
When a server controller implements a contract-first interface, it currently does not generate a *TestAPI client, and this thus it's harder to write tests with access to the response status code and headers etc.

This modifies the TestClientWriter, to also generate the TestAPI for those controllers that implement a contract-first interface.