### PR TITLE
Fix for @Default ignored for "contract-first" style controller

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
@@ -73,8 +73,7 @@ public class MethodReader {
 
     initWebMethodViaAnnotation();
 
-    this.superMethods =
-        superMethods(element.getEnclosingElement(), element.getSimpleName().toString());
+    this.superMethods = superMethods(element);
     superMethods.forEach(m -> methodRoles.addAll(Util.findRoles(m)));
     this.throwsList = element.getThrownTypes();
     this.hasThrows = !throwsList.isEmpty();
@@ -334,6 +333,7 @@ public class MethodReader {
     final ParamType defaultParamType = formMarker ? ParamType.FORMPARAM : ParamType.QUERYPARAM;
 
     final List<? extends VariableElement> parameters = element.getParameters();
+    final List<? extends VariableElement> annotatedParameters = annotatedElement().getParameters();
     for (int i = 0; i < parameters.size(); i++) {
       final VariableElement p = parameters.get(i);
       TypeMirror typeMirror;
@@ -344,7 +344,7 @@ public class MethodReader {
       }
       final String rawType = Util.typeDef(typeMirror);
       final UType type = Util.parse(typeMirror.toString());
-      final MethodParam param = new MethodParam(p, type, rawType, defaultParamType, formMarker);
+      final MethodParam param = new MethodParam(annotatedParameters.get(i), type, rawType, defaultParamType, formMarker);
       params.add(param);
 
       if (CoreWebMethod.GET.equals(webMethod) && isBodyParam(param)) {

--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/ProcessingContext.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -170,19 +169,19 @@ public final class ProcessingContext {
     return CTX.get().typeUtils.asMemberOf(declaredType, element);
   }
 
-  public static List<ExecutableElement> superMethods(Element element, String methodName) {
+  public static List<ExecutableElement> superMethods(ExecutableElement method) {
     final Types types = CTX.get().typeUtils;
-    return types.directSupertypes(element.asType()).stream()
+    final Elements elements = CTX.get().elementUtils;
+    final TypeElement enclosingType = (TypeElement) method.getEnclosingElement();
+    return types.directSupertypes(enclosingType.asType()).stream()
       .filter(type -> !type.toString().contains("java.lang.Object"))
-      .map(superType -> {
+      .flatMap(superType -> {
         final var superClass = (TypeElement) types.asElement(superType);
-        for (final var method : ElementFilter.methodsIn(CTX.get().elementUtils.getAllMembers(superClass))) {
-          if (method.getSimpleName().contentEquals(methodName)) {
-            return method;
-          }
-        }
-      return null;
-    }).filter(Objects::nonNull).collect(Collectors.toList());
+        return ElementFilter.methodsIn(elements.getAllMembers(superClass)).stream();
+      })
+      .filter(superMethod -> elements.overrides(method, superMethod, enclosingType))
+      .distinct()
+      .collect(Collectors.toList());
   }
 
   public static PlatformAdapter platform() {

--- a/tests/test-nima/src/main/java/org/example/QueryDefaultsApi.java
+++ b/tests/test-nima/src/main/java/org/example/QueryDefaultsApi.java
@@ -1,0 +1,17 @@
+package org.example;
+
+import io.avaje.http.api.Default;
+import io.avaje.http.api.Get;
+import io.avaje.http.api.Path;
+import io.avaje.http.api.Produces;
+import io.avaje.http.api.QueryParam;
+
+@Path("queryDefaults")
+interface QueryDefaultsApi {
+
+  @Produces("text/plain")
+  @Get
+  String defaults(
+      @QueryParam("useMaster") @Default("false") boolean useMaster,
+      @QueryParam("withFleets") @Default("false") boolean withFleets);
+}

--- a/tests/test-nima/src/main/java/org/example/QueryDefaultsController.java
+++ b/tests/test-nima/src/main/java/org/example/QueryDefaultsController.java
@@ -1,0 +1,12 @@
+package org.example;
+
+import io.avaje.http.api.Controller;
+
+@Controller
+class QueryDefaultsController implements QueryDefaultsApi {
+
+  @Override
+  public String defaults(boolean useMaster, boolean withFleets) {
+    return useMaster + "," + withFleets;
+  }
+}

--- a/tests/test-nima/src/test/java/org/example/HelloControllerTest.java
+++ b/tests/test-nima/src/test/java/org/example/HelloControllerTest.java
@@ -9,6 +9,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HelloControllerTest extends BaseWebTest {
 
   @Test
+  void contractFirstQueryDefaults() {
+    HttpResponse<String> res = client().request()
+      .path("queryDefaults")
+      .GET()
+      .asPlainString();
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("false,false");
+  }
+
+  @Test
   void listParamOne() {
     HttpResponse<String> res = client().request()
       .path("listParams")


### PR DESCRIPTION
Given an interface with a `@Default` on a `@QueryParam` like:
```java
@QueryParam("useMaster") @Default("false") boolean useMaster
```
The `@Default("false")` was not being read and applied on the query parameter. This resulted in a null being used and a InvalidPathArgumentException.

```
io.avaje.http.api.InvalidPathArgumentException: path element is null
 at io.avaje.http.api.PathTypeConversion.checkNull(PathTypeConversion.java:52)
 at io.avaje.http.api.PathTypeConversion.asBoolean(PathTypeConversion.java:178)
 at io.avaje.http.api.PathTypeConversion.asBool(PathTypeConversion.java:186)
 ...
```

#### The fix has 2 parts:
A) Improve ProcessingContext.superMethods() which only matched on name and instead match also on parameter types etc 
B) Fix MethodReader to use the annotated element [from the super method / interface] as the controller method itself does not have those annotations like `@Default`.

--------------
In the generated code, with the bug we see the null value like:
```java
var useMaster = asBool(queryParams.contains("useMaster") ? queryParams.get("useMaster") : null);
```
... when we expect the default value of "false" like:
```java
var useMaster = asBool(queryParams.contains("useMaster") ? queryParams.get("useMaster") : "false");
```


---------------

## Workaround

Copy the annotations from the interface (like `@QueryParam("useMaster") @Default("false")`) to the controller method. This duplicates the annotations so not ideal but does mean that the generated code includes the default values as expected. 