### PR TITLE
generator: Recover parameter names for contract-first controllers and…

### DIFF
--- a/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
+++ b/http-generator-core/src/main/java/io/avaje/http/generator/core/MethodReader.java
@@ -345,6 +345,10 @@ public class MethodReader {
       final String rawType = Util.typeDef(typeMirror);
       final UType type = Util.parse(typeMirror.toString());
       final MethodParam param = new MethodParam(annotatedParameters.get(i), type, rawType, defaultParamType, formMarker);
+      if (param.name().equals("arg" + i) && !p.getSimpleName().toString().equals("arg" + i)) {
+        // contract first interface with arg0, aeg1 but controller with param names to match on
+        param.overrideVarName(p.getSimpleName().toString(), defaultParamType);
+      }
       params.add(param);
 
       if (CoreWebMethod.GET.equals(webMethod) && isBodyParam(param)) {
@@ -355,6 +359,7 @@ public class MethodReader {
 
       param.addImports(bean);
     }
+    checkArgumentNames();
   }
 
   private static boolean isBodyParam(MethodParam param) {

--- a/tests/test-nima-jsonb/src/main/java/org/example/ContractApi.java
+++ b/tests/test-nima-jsonb/src/main/java/org/example/ContractApi.java
@@ -1,0 +1,26 @@
+package org.example;
+
+import io.avaje.http.api.Get;
+import io.avaje.http.api.Path;
+import io.avaje.http.api.Produces;
+import io.avaje.http.api.QueryParam;
+
+@Path("/contract")
+public interface ContractApi {
+
+  @Produces("text/plain")
+  @Get("users/{userId}")
+  String getUser(String userId);
+
+  @Produces("text/plain")
+  @Get("repos/{org}/{repo}")
+  String getRepo(String repo, String org);
+
+  @Produces("text/plain")
+  @Get("search")
+  String search(@QueryParam("q") String q, @QueryParam String filter);
+
+  @Produces("text/plain")
+  @Get("orgs/{org}/users/{user}/roles")
+  String userRoles(String org, String user, @QueryParam("activeOnly") Boolean activeOnly);
+}

--- a/tests/test-nima-jsonb/src/main/java/org/example/ContractController.java
+++ b/tests/test-nima-jsonb/src/main/java/org/example/ContractController.java
@@ -1,0 +1,27 @@
+package org.example;
+
+import io.avaje.http.api.Controller;
+
+@Controller
+public class ContractController implements ContractApi {
+
+  @Override
+  public String getUser(String userId) {
+    return "user:" + userId;
+  }
+
+  @Override
+  public String getRepo(String repo, String org) {
+    return "org:" + org + ",repo:" + repo;
+  }
+
+  @Override
+  public String search(String q, String filter) {
+    return "q:" + q + ",filter:" + filter;
+  }
+
+  @Override
+  public String userRoles(String org, String user, Boolean activeOnly) {
+    return "org:" + org + ",user:" + user + ",activeOnly:" + activeOnly;
+  }
+}

--- a/tests/test-nima-jsonb/src/test/java/org/example/ContractControllerTest.java
+++ b/tests/test-nima-jsonb/src/test/java/org/example/ContractControllerTest.java
@@ -1,0 +1,70 @@
+package org.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.http.client.HttpClient;
+
+public class ContractControllerTest {
+
+  private static TestPair pair = new TestPair();
+  private static HttpClient client = pair.client();
+
+  @AfterAll
+  static void end() {
+    pair.stop();
+  }
+
+  @Test
+  void getUser() {
+    HttpResponse<String> res = client.request()
+      .path("contract/users/42")
+      .GET()
+      .asString();
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("user:42");
+  }
+
+  @Test
+  void getRepo_swappedParameterOrder() {
+    // Route is /contract/repos/{org}/{repo}, method signature is (repo, org)
+    // Name-based matching ensures "avaje" is org and "avaje-http" is repo
+    HttpResponse<String> res = client.request()
+      .path("contract/repos/avaje/avaje-http")
+      .GET()
+      .asString();
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("org:avaje,repo:avaje-http");
+  }
+
+  @Test
+  void search_namedAndBareQueryParams() {
+    HttpResponse<String> res = client.request()
+      .path("contract/search")
+      .queryParam("q", "hello")
+      .queryParam("filter", "active")
+      .GET()
+      .asString();
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("q:hello,filter:active");
+  }
+
+  @Test
+  void userRoles_pathAndQueryParams() {
+    HttpResponse<String> res = client.request()
+      .path("contract/orgs/my-org/users/rob/roles")
+      .queryParam("activeOnly", true)
+      .GET()
+      .asString();
+
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("org:my-org,user:rob,activeOnly:true");
+  }
+}

--- a/tests/test-nima-jsonb/src/test/java/org/example/TestPair.java
+++ b/tests/test-nima-jsonb/src/test/java/org/example/TestPair.java
@@ -56,6 +56,10 @@ public class TestPair {
     TestController$Route tcr = new TestController$Route(tc, (a,b,c)->{}, jsonb, cr);
 
     routing.addFeature(tcr);
+
+    var cc = new ContractController();
+    var ccRoute = new ContractController$Route(cc);
+    routing.addFeature(ccRoute);
     return routing;
   }
 }


### PR DESCRIPTION
… run checkArgumentNames in MethodReader

When implementing an interface from a precompiled jar without -parameters, method parameter names from the interface default to arg0, arg1, etc. Fall back to the parameter names declared on the implementing controller method in source code, and run checkArgumentNames() during MethodReader.read() so all server generators (Helidon, Jex, Javalin) positionally match path segments from the route URL.

Add ContractControllerTest in test-nima-jsonb covering name-matched path params, swapped parameter orders, and query parameter binding.